### PR TITLE
Dernières typos

### DIFF
--- a/EtAgreg.tex
+++ b/EtAgreg.tex
@@ -7,17 +7,17 @@
 \section*{Ce cours à l'agrégation ?}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Peut-on utiliser ce cours pour \textbf{les oraux d'\href{http://agreg.org/}{agrégation}} (de mathématiques) ?  Cela est une question qui m'est arrivée quelque fois.  La réponse courte est : « je ne sais pas », et voici quelques éléments de réponses plus longues.
+Peut-on utiliser ce cours pour \textbf{les oraux d'\href{http://agreg.org/}{agrégation}} (de mathématiques) ?  Cela est une question qui m'est arrivée quelques fois.  La réponse courte est : « je ne sais pas », et voici quelques éléments de réponses plus longues.
 
 \begin{enumerate}
     \item
-        La version 2012 a été disponible dans la bibliothèque à Paris, pour au moins la cession 2013.
-    \item
-        En 2014 un candidat (qui a réussi, je n'en dirai pas plus) en a amené une version avec lui et l'a utilisé sans être inquiété.
+        La version 2012 a été disponible dans la bibliothèque à Paris, pour au moins la session 2013.
     \item 
         Il m'a été signalé en 2012 (de façon non officielle : par courrier privé) que les candidats ne pourraient pas apporter de copies imprimées « à la maison ».
     \item
-        Quelque mois avant les oraux de 2015, à cause d'un changement de règlement de dernière minute, il a été refusé\footnote{De façon on ne peut moins officielle : par mail privé à moi-même et à au moins un autre candidat qui avait demandé.} parce que les ouvrages « non commercialisés ou non suffisamment diffusés » ont besoin d'une autorisation explicite.
+        En 2014 un candidat (qui a réussi, je n'en dirai pas plus) en a amené une version avec lui et l'a utilisé sans être inquiété.
+    \item
+        Quelque mois avant les oraux de 2015, à cause d'un changement de règlement de dernière minute, il a été refusé\footnote{De façon on ne peut moins officielle : par mail privé à moi-même et à au moins un autre candidat qui avait demandé.}, parce que les ouvrages « non commercialisés ou non suffisamment diffusés » ont besoin d'une autorisation explicite.
     \item
         J'ai demandé cette autorisation en mai 2015. Lorsque j'aurai une réponse, je vous le ferai savoir ici\footnote{Si vous croyez en la règle du « trois mois sans réponses équivaut à approbation »\ldots}.
     \item
@@ -29,7 +29,7 @@ Peut-on utiliser ce cours pour \textbf{les oraux d'\href{http://agreg.org/}{agr�
 
         D'ailleurs, si une version est disponible dans la bibliothèque de votre établissement, faites-le moi savoir.
     \item
-        J'ai demandé ce que ferait un surveillant si un candidat sortait de son sac une version avec le cachet et la cote d'une bibliothèque. Pas de réponses.
+        J'ai demandé ce que ferait un surveillant si un candidat sortait de son sac une version avec le cachet et la cote d'une bibliothèque. Pas de réponse.
     \item
         Enfin, ce cours est commercialisé. En effet pour la somme de 100€, je vous en imprime et envoie une version dédicacée (envoyez-moi un mail pour me dire la dédicace que vous souhaitez). Frais d'envoi non compris. Vous noterez que 100€, c'est tout à fait dans les prix de ce que vous devriez débourser dans le commerce pour un ouvrage de cette taille\footnote{La licence vous permet de le commercialiser pour votre profit, donc n'hésitez pas à me faire concurrence.}.
 \end{enumerate}


### PR DESCRIPTION
Il restait une erreur de frappe, et la remarque sur 2012 semble mieux placée avant la remarque sur 2014.
