### PR TITLE
Typo sur le sous-titre

### DIFF
--- a/gardeFrido.tex
+++ b/gardeFrido.tex
@@ -12,7 +12,7 @@
     \hrule\par
     \vspace{2mm}
     \begin{center}
-        \Huge \bfseries Le Frido \\  {\small Les quelque premières années de mathématique }     % Ici il y avait \par
+        \Huge \bfseries Le Frido \\  {\small Les quelques premières années de mathématiques }     % Ici il y avait \par
     \normalsize
     \url{http://student.ulb.ac.be/~lclaesse/lefrido.pdf}
     \end{center}


### PR DESCRIPTION
« Les quelque premières années de mathématique » → « Les quelques premières années de mathématiques ».