### PR TITLE
Typo : un \item en trop

### DIFF
--- a/remerciements.tex
+++ b/remerciements.tex
@@ -12,7 +12,7 @@ Les remerciements sont mis dans l'ordre chronologique approximatif.
             \item
                 Carlotta Donadello pour la partie géométrie analytique : topologie dans \( \eR^n\), courbes, intégrales, limites. (Université de Franche-Comté 2010-2012)
             \item
-                Lilian Besson pour m'avoir signalé un paquet de fautes et quelques points pas clairs en statistiques.
+                Lilian Besson pour m'avoir signalé un paquet de fautes, et quelques points pas clairs en statistiques.
         \end{enumerate}
     \item[Ceux à qui je dois beaucoup plus que un ou deux développements]
         \begin{enumerate}
@@ -21,17 +21,16 @@ Les remerciements sont mis dans l'ordre chronologique approximatif.
             \item
                 Le site \url{http://www.les-mathematiques.net} m'a donné les preuves de nombreux résultats.
             \item
-                Pierre Monmarché\cite{PAXrsMn} pour son document en ligne tout plein de développements. 
+                Pierre Monmarché\cite{PAXrsMn} pour son document en ligne tout plein de développements.
         \end{enumerate}
     \item[Autres contributions et aides]
 
 
 \begin{enumerate}
     \item
-        Plein de monde pour diverses contributions à des énoncés d'exercices. Pierre Bieliavsky pour les énoncés d'analyse numérique (MAT1151 à Louvain la Neuve 2009-2010). Jonathan Di Cosmo pour certaines corrections de MAT1151. François Lemeux, exercices sur les normes de matrices et correction de coquilles. Martin Meyer et Mustapha Mokhtar-Kharroubi pour certains exercices de outils mathématiques (surtout ceux des DS et examens).
-    \item 
+        Plein de monde pour diverses contributions à des énoncés d'exercices. Pierre Bieliavsky pour les énoncés d'analyse numérique (MAT1151 à Louvain la Neuve 2009-2010). Jonathan Di Cosmo pour certaines corrections de MAT1151. François Lemeux pour des exercices sur les normes de matrices et correction de coquilles. Martin Meyer et Mustapha Mokhtar-Kharroubi pour certains exercices du document ``outils mathématiques'' (surtout ceux des DS et examens).
     \item
-        Mihai Bostan nous a donné ses notes manuscrites de son cours présentiel de géométrie analytique 2009-2010. (presque) Toute la structure du cours de géométrie analytique lui est due (qui est maintenant fondue un peu partout dans les chapitres d'analyse).
+        Mihai Bostan nous a donné ses notes manuscrites de son cours présentiel de géométrie analytique 2009-2010. (Presque) Toute la structure du cours de géométrie analytique lui est due (qui est maintenant fondue un peu partout dans les chapitres d'analyse).
     \item
          Mustapha Mokhtar-Kharroubi pour la matière et la structure du cours d'outils mathématiques.
     \item


### PR DESCRIPTION
Juste une petite correction sur [remerciements.tex](https://github.com/LaurentClaessens/mazhe/blob/master/remerciements.tex).

Et le Frido compile toujours bien chez moi, parfait.