### PR TITLE
Cvg dominée de Lebesgue : |f_n| <= g suffit.

### DIFF
--- a/135_mesure.tex
+++ b/135_mesure.tex
@@ -481,9 +481,9 @@ Nous avons évidemment \( g_n(x)=0\) tandis que \( \int_{\mathopen[ 0 , 2 \mathc
 \begin{theorem}[Convergence dominée de Lebesgue]        \label{ThoConvDomLebVdhsTf}
     Soit \( (f_n)_{n\in\eN}\) une suite de fonctions intégrables sur \( (\Omega,\tribA,\mu)\) à valeurs dans \( \eC\) ou \( \eR\). Nous supposons que  \( f_n\to f\) simplement sur \( \Omega\) presque partout et qu'il existe une fonction intégrable \( g\) telle que
     \begin{equation}
-        | f_n(x) |< g(x) 
+        | f_n(x) | \leq g(x) 
     \end{equation}
-    pour presque\footnote{Si il n'y avait pas le «presque» ici, ce théorème serait à peu près inutilisable en probabilité ou en théorie des espaces \( L^p\), comme dans la démonstration du théorème de Fischer-Riesz \ref{ThoGVmqOro} par exemple.} tout \( x\in\Omega\) et pour tout \( n\in \eN\). Alors
+    pour presque\footnote{S'il n'y avait pas le «presque» ici, ce théorème serait à peu près inutilisable en probabilité ou en théorie des espaces \( L^p\), comme dans la démonstration du théorème de Fischer-Riesz \ref{ThoGVmqOro} par exemple.} tout \( x\in\Omega\) et pour tout \( n\in \eN\). Alors
     \begin{enumerate}
         \item
             \( f\) est intégrable,


### PR DESCRIPTION
Cvg dominée de Lebesgue : ``|f_n| <= g`` suffit.
Dans la preuve on écrit un ``<=`` et pas un strict ``<``.

Et mini typo : Si il → S'il.