### PR TITLE
Update .gitignore, and 145_theorie.tex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,22 @@
+## .gitignore for https://github.com/LaurentClaessens/mazhe
+# System files
+.viminfo
+.directory
+
+# Folders
 Dépendances/*
+vieux_trucs/*
+
+# Useless runtime generated documents
 mazhe.html
 README.html
-makefile~
 core
-garde?.tex
-garde?.pdf
-mat?.pdf
 volumes
-vieux_trucs/*
-verbatiminput.py
 ISBN.txt
 travail.txt
+
+# Useless Python files
+verbatiminput.py
 lst_actu.py
 lst_num.py
 lst_Mactu.py
@@ -22,6 +28,9 @@ lst_futur.py
 lst_intro.py
 lst_CdI.py
 lst_Mactu.py
+pytextools.xml
+
+# Ignored LaTeX/PDF files
 actu-mazhe_pytex.pdf
 actu-mazhe_pytex.tex
 CdI-mazhe_pytex.tex
@@ -31,6 +40,8 @@ all-mazhe_pytex.pdf
 all-mazhe_pytex.tex
 bctu-mazhe_pytex.pdf
 bctu-mazhe_pytex.tex
+outils_math-outils_pytex.pdf
+outils_math-outils_pytex.tex
 enseignement-mazhe_pytex.pdf
 everything-mazhe_pytex.pdf
 futur-mazhe_pytex.pdf
@@ -40,11 +51,15 @@ renomage.pdf
 test_couleur.pdf
 to_be_checked.tex
 corr.tex
-tikzfile*
-tikzFIGLabelFig*.dpth
-tikzFIGLabelFig*.nlo
-tikzFIGLabelFig*.log
-Inter_*
+garde?.tex
+garde?.pdf
+mat?.pdf
+[^0]*-mahze-*.pdf
+CorrPytexFile*
+0-*.pdf
+*-source-*.tex
+
+# LaTeX garbage files
 *.comment
 *.log
 *.bbl
@@ -59,16 +74,18 @@ Inter_*
 *.auxlock
 *.ind
 *.ilg
-*.bak
-*.*~
-*.swp
 *.synctex.gz
-[^0]*-mahze-*.pdf
-CorrPytexFile*
-0-*.pdf
-.viminfo
-.directory
-pytextools.xml
-*-source-*.tex
-outils_math-outils_pytex.pdf
-outils_math-outils_pytex.tex
+
+# Backup files (nano, emacs etc)
+*bak
+*~
+*sw[po]
+*.py[co]
+\#*\#
+
+# TiKZ useless files
+tikzfile*
+tikzFIGLabelFig*.dpth
+tikzFIGLabelFig*.nlo
+tikzFIGLabelFig*.log
+Inter_*

--- a/145_theorie.tex
+++ b/145_theorie.tex
@@ -10,25 +10,25 @@ D'autres lectures agréables dans \cite{GianlucaB}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 \begin{definition}
-	Soit $F$ une fonction à valeurs réelles définie sur $X\times D$ où $X$ et $ D$ sont des espaces vectoriels réels normés. Le problème de la recherche des solutions de 
+	Soit $F$ une fonction à valeurs réelles définie sur $X\times D$ où $X$ et $D$ sont des espaces vectoriels réels normés. Le problème de la recherche des solutions de
 	\begin{equation}
 		F(x,d)=0
 	\end{equation}
-	est dit \defe{stable}{stable} si 
+	est dit \defe{stable}{stable} si
 	\begin{enumerate}
-		\item 
+		\item
 			la solution $x=x(d)$ existe et est unique pour tout $d$;
 		\item \label{ItemProbStableB}
 			Pour tout $\eta>0$, et pour tout $d_0$, il existe un nombre $K>0$ tel que $|d-d_0|<\eta$ entraine $|x(d)-x(d_0)|\;\leq\;K\;|d-d_0|$.
 	\end{enumerate}
 \end{definition}
-Le nombre 
-\begin{equation}		\label{EqDefAABSOLU}
+Le nombre
+\begin{equation}        \label{EqDefAABSOLU}
 	K_{abs}(d_0,\eta):=\sup_{d\text{ tel que $|d_0-d|<\eta$}}\frac{|x(d)-x(d_0)|}{|d-d_0|}
 \end{equation}
 est appelé le \defe{conditionnement absolu}{conditionnement!absolu} du problème autour de $d_0$.
 
-\begin{definition}	
+\begin{definition}
 	Soit $F(x,d)=0$ un problème stable de conditionnement absolu $K_{\text{abs}}(d,\eta)$.  Le conditionnement relatif est défini par
 	\begin{equation}
 		K_{\text{rel}}(d,\eta):=K_{\text{abs}}(d,\eta)\frac{|d|}{|x(d)|}.
@@ -37,7 +37,7 @@ est appelé le \defe{conditionnement absolu}{conditionnement!absolu} du problèm
 \end{definition}
 
 Un résultat pratique pour étudier le conditionnement d'un problème est le suivant.
-\begin{corollary}		\label{CorConditionnementNormeNabla}
+\begin{corollary}       \label{CorConditionnementNormeNabla}
 	Soit $x=x(d)$ un problème stable. Supposons $\eD$ de dimension finie, supposons que $U$ est ouvert dans $\eD$. Supposons encore $x\colon U\to \eR$ différentiable en $d_0$. Alors quand $\eta$ est petit, on a
 	\begin{equation}
 		K_{\text{abs}}^{\eta}(d_0)\sim \| \nabla x(d_0) \|.
@@ -55,7 +55,7 @@ Un résultat pratique pour étudier le conditionnement d'un problème est le sui
 	\begin{equation}
 		f(d)=x(d_0)+K| d-d_0 |
 	\end{equation}
-	majore $x(d)$, et donc on a 
+	majore $x(d)$, et donc on a
 	\begin{equation}
 		\big| x(d)-x(d_0) \big|\leq K| d-d_0 |.
 	\end{equation}
@@ -64,13 +64,13 @@ Un résultat pratique pour étudier le conditionnement d'un problème est le sui
 \end{proof}
 
 \begin{example} \label{ExRZrOeoi}
-    Un exemple de problème stable de la forme  $x=x(d)$ avec $d\in\eR$ et $x \in C^0(\eR)\setminus C^1(\eR)$.
+	Un exemple de problème stable de la forme  $x=x(d)$ avec $d\in\eR$ et $x \in C^0(\eR)\setminus C^1(\eR)$.
 
 	La fonction
 	\begin{equation}
 		x(d)=\begin{cases}
-			0	&	\text{si $x\geq 0$}\\
-			x	&	 \text{si $x>0$}
+			0   &   \text{si $x\geq 0$}\\
+			x   &   \text{si $x>0$}
 		\end{cases}
 	\end{equation}
 	est continue, mais pas $C^1$ (non dérivable en $x=0$). La dérivée est partout bornée par $1$, et donc le problème est stable.
@@ -87,7 +87,7 @@ Un résultat pratique pour étudier le conditionnement d'un problème est le sui
 \end{example}
 
 \begin{example} \label{PIluknK}
-    Un exemple de problème instable de la forme  $x=x(d)$ avec $d\in\eR$ et $x \in C^0(\eR)$.
+	Un exemple de problème instable de la forme $x=x(d)$ avec $d\in\eR$ et $x \in C^0(\eR)$.
 
 	Un exemple assez classique de fonction dont la dérivée n'est pas bornée sans pour autant que la fonction aie un comportement immoral\footnote{Penser à $x\mapsto x\sin(1/x)$.} est $x\mapsto\sqrt{x}$. Afin d'avoir une fonction définie sur $\eR$ tout entier, nous regardons la fonction
 	\begin{equation}
@@ -100,7 +100,6 @@ Un résultat pratique pour étudier le conditionnement d'un problème est le sui
 	Il n'est pas possible de trouver un $K$ qui majore ce rapport. Le problème est donc mal conditionné.
 
 	Attention : dans ce calcul nous avons supposé $d>0$. Pensez à adapter au cas $d<0$.
-
 \end{example}
 
 %---------------------------------------------------------------------------------------------------------------------------
@@ -113,9 +112,9 @@ Un fil conducteur du lemme \ref{LemITCxqyS} et des exemples \ref{ExRZrOeoi}, \re
 
 Il faut cependant parfois faire acte d'imagination. La fonction $x\mapsto| x |$ n'est pas dérivable en $0$. Il n'empêche que $K=1$ fait fonctionner la définition de la stabilité. Remarquez que $K=1$ est le supremum de la dérivée là où elle existe.
 
-À partir du moment où c'est clair que le $K$ est le supremum de la dérivée, on comprend pourquoi c'est le gradient qui arrive dans le corollaire \ref{CorConditionnementNormeNabla}. En effet, le gradient indique la direction de plus grande pente. C'est donc bien dans cette direction qu'il faut chercher la «plus grande dérivée».
+À partir du moment où c'est clair que le $K$ est le supremum de la dérivée, on comprend pourquoi c'est le gradient qui arrive dans le corollaire \ref{CorConditionnementNormeNabla}. En effet, le gradient indique la direction de plus grande pente. C'est donc bien dans cette direction qu'il faut chercher la ``plus grande dérivée''.
 
-\begin{proposition}	
+\begin{proposition}
 	Pour le problème stable $x=x(d)$ avec $x\in C^1(\eR^n,\eR)$, on a
 	\begin{equation}
 		K_{abs}(d)\sim|dx_d|_{\mbox{op}}
@@ -132,7 +131,7 @@ Il faut cependant parfois faire acte d'imagination. La fonction $x\mapsto| x |$ 
 %---------------------------------------------------------------------------------------------------------------------------
 \label{SubSecMethodeNewton}
 
-Nous parlons de méthode de Newton en dimension \( n\) au théorème \ref{ThoHGpGwXk}.
+Nous parlons de méthode de Newton en dimension $n$ au théorème \ref{ThoHGpGwXk}.
 
 La méthode de Newton consiste a exprimer la solution $x$ de $f(x)=0$ avec $f\in C^1(\eR)$ comme limite d'une suite $\{x_n\}_{n\in\eN}$ définie par récurrence par la formule
 \begin{equation}
@@ -140,8 +139,8 @@ La méthode de Newton consiste a exprimer la solution $x$ de $f(x)=0$ avec $f\in
 \end{equation}
 où $x_0$ est arbitraire.
 
-Si on veut exprimer cela en termes d'algorithmes, nous disons que l'algorithme de Newton est donné par la suite de problèmes
-\begin{equation}		\label{EqFPourNewtonUn}
+Si on veut exprimer cela en terme d'algorithme, nous disons que l'algorithme de Newton est donné par la suite de problèmes
+\begin{equation}        \label{EqFPourNewtonUn}
 	F_n(x_{n+1},x_n,f)=x_{n+1}-x_n+\frac{ f(x_n) }{ f'(x_n) }.
 \end{equation}
 La donnée du problème est la fonction $f$, et rien que elle.
@@ -153,8 +152,8 @@ Plus précisément, une fois que la fonction $f$ est donnée, il existe une infi
 La méthode de Newton consiste à sélectionner une partie de ces problèmes de la façon suivante :
 \begin{subequations}
 	\begin{numcases}{}
-		F_0=G_{x_0}\\
-		F_n=G_{x_n}.
+		F_0 = G_{x_0}\\
+		F_n = G_{x_n}.
 	\end{numcases}
 \end{subequations}
 Le problème $F_0$ fournit un nombre $x_1$ qui nous permet de sélectionner le problème $G_{x_1}$ qui va fournir le nombre $x_2$, etc.
@@ -181,13 +180,13 @@ Pour résoudre un système linéaire d'équations, nous échelonnons la matrice 
 \begin{equation}
 	\begin{aligned}[]
 		A&=\begin{pmatrix}
-			2	&	4	&	-6	\\
-			1	&	5	&	3	\\
-			1	&	3	&	2
+			2   &   4   &   -6  \\
+			1   &   5   &   3   \\
+			1   &   3   &   2
 		\end{pmatrix}, &\text{et}&&b=\begin{pmatrix}
-			-4	\\ 
-			10	\\ 
-			5	
+			-4  \\
+			10  \\
+			5
 		\end{pmatrix}.
 	\end{aligned}
 \end{equation}
@@ -203,17 +202,17 @@ Ensuite, on commence à échelonner et le second problème est
 \begin{equation}
 	F_2\big(x_2,(A_2,b_2)\big)=A_2x_2-b_2=0
 \end{equation}
-avec 
+avec
 \begin{equation}
 	\begin{aligned}[]
 		A&=\begin{pmatrix}
-			2	&	4	&	-6	\\
-			0	&	3	&	6	\\
-			0	&	1	&	5
+			2   &   4   &   -6  \\
+			0   &   3   &   6   \\
+			0   &   1   &   5
 		\end{pmatrix}, &\text{et}&&b=\begin{pmatrix}
-			-4	\\ 
-			12	\\ 
-			13	
+			-4  \\
+			12  \\
+			13
 		\end{pmatrix}.
 	\end{aligned}
 \end{equation}
@@ -221,21 +220,21 @@ Le troisième problème sera
 \begin{equation}
 	F_3\big(x_3,(A_3,b_3)\big)=A_3x_3-b_3=0
 \end{equation}
-avec 
+avec
 \begin{equation}
 	\begin{aligned}[]
 		A&=\begin{pmatrix}
-			2	&	4	&	-6	\\
-			0	&	3	&	6	\\
-			0	&	0	&	3
+			2   &   4   &   -6  \\
+			0   &   3   &   6   \\
+			0   &   0   &   3
 		\end{pmatrix}, &\text{et}&&b=\begin{pmatrix}
-			-4	\\ 
-			12	\\ 
-			3	
+			-4  \\
+			12  \\
+			3
 		\end{pmatrix}.
 	\end{aligned}
 \end{equation}
-Ce problème est facile à résoudre «à la main». Nous nous arrêtons donc ici avec l'algorithme, et nous trouvons le $x_3$ qui résous le problème $F_3$.
+Ce problème est facile à résoudre ``à la main''. Nous nous arrêtons donc ici avec l'algorithme, et nous trouvons le $x_3$ qui résous le problème $F_3$.
 
 L'algorithme de résolution de systèmes linéaires d'équations a les propriétés suivantes, à mettre en contraste avec celles de Newton :
 \begin{enumerate}
@@ -254,7 +253,7 @@ L'algorithme de résolution de systèmes linéaires d'équations a les propriét
 \subsection{Définitions}
 %---------------------------------------------------------------------------------------------------------------------------
 
-	Nous allons maintenant formaliser en donnant quelques définitions pour nommer les propriétés que nous avons vues. D'abord, un algorithme est une suite de problèmes. Un \defe{algorithme}{algorithme} pour résoudre un problème $F(x,d)=0$ est une suite de problèmes $\{F_n(x_n,d_n)=0\}_{n\in\eN}$.  
+	Nous allons maintenant formaliser en donnant quelques définitions pour nommer les propriétés que nous avons vues. D'abord, un algorithme est une suite de problèmes. Un \defe{algorithme}{algorithme} pour résoudre un problème $F(x,d)=0$ est une suite de problèmes $\{F_n(x_n,d_n)=0\}_{n\in\eN}$.
 
 \begin{definition}
 	Un tel algorithme est dit  \defe{fortement consistant}{algorithme!fortement consistant} si pour toutes données admissibles $d_n$, on a
@@ -276,11 +275,11 @@ L'algorithme est dit \defe{stable}{algorithme!stable} si pour tout $n$ le probl�
 \end{equation}
 où $K_n$ est le conditionnement relatif du problème $F_n(x_n,d_n)=0$.
 
-\begin{definition}		\label{DefAlgoConverge}
+\begin{definition}      \label{DefAlgoConverge}
 	Un algorithme est dit \defe{convergent}{algorithme!convergent} (en $d$) si pour tout $\epsilon>0$, il existe $N=N(\epsilon)$ et $\delta=\delta(N,\epsilon)$ tels que pour $n\geq0$ et $|d-d_n|<\delta$, on ait $|x(d)-x_n(d_n)|<\epsilon$.
 \end{definition}
 
-\begin{remark}		\label{RemConvAlgoNewton}
+\begin{remark}      \label{RemConvAlgoNewton}
 Dans le cas de l'algorithme de Newton, nous avons vu que la donnée $d_n$ du problème $F_n$ était en fait la même que la donnée initiale $d$, donc nous avons $d_n=d$, et par conséquent nous avons toujours $| d-d_n |<\delta$. Dans ce cas, la définition de la convergence revient à demander que la suite numérique des $x_n$ converge vers la solution $x$.
 \end{remark}
 
@@ -293,7 +292,7 @@ Dans le cas des matrices par contre, les données sont très différentes les un
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 \begin{definition}
-	Soit $x$ un réel. On définit sa \defe{représentation en virgule fixe}{représentation!virgule fixe} par 
+	Soit $x$ un réel. On définit sa \defe{représentation en virgule fixe}{représentation!virgule fixe} par
 	\begin{equation}
 		x=\{[x_nx_{n-1}...x_0,x_{-1}...x_{-m}], b, s\}
 	\end{equation}
@@ -301,18 +300,18 @@ Dans le cas des matrices par contre, les données sont très différentes les un
 	\begin{equation}
 		x=(-1)^{s}\sum_{j=-m}^nx_j.b^j.
 	\end{equation}
-	On définit sa \defe{représentation en \href{http://docs.python.org/tutorial/floatingpoint.html}{virgule flottante} normalisée}{Représentation!virgule flottante normalisée} par 
+	On définit sa \defe{représentation en \href{https://docs.python.org/tutorial/floatingpoint.html}{virgule flottante} normalisée}{Représentation!virgule flottante normalisée} par
 	\begin{equation}
 		\{[a_1...a_t],b,e,s\}
 	\end{equation}
 	où $e\in\eZ,e\in[L,U]$ et $a_j\in\eN;0\leq a_j<b; a_1\geq1$ suivant la formule
-	\begin{equation}		\label{EqRepreFlotNOrm}
+	\begin{equation}        \label{EqRepreFlotNOrm}
 		x=(-1)^sb^e\sum_{j=1}^ta_jb^{-j}.
 	\end{equation}
 \end{definition}
 
 \begin{definition}
-	L'\defe{erreur relative}{erreur relative} commise en remplaçant un nombre réel $x$ par une valeur approchée $\hat{x}$ est définie par 
+	L'\defe{erreur relative}{erreur relative} commise en remplaçant un nombre réel $x$ par une valeur approchée $\hat{x}$ est définie par
 	\begin{equation}
 		\epsilon_x:=\left|\frac{x-\hat{x}}{x}\right|.
 	\end{equation}
@@ -322,29 +321,29 @@ L'erreur relative n'est pas influencée par l'ordre de grandeur de \( x\). En ef
 
 Le nombre de chiffres significatifs correct dans l'approximation est donné par \( -\log_{10}(\epsilon_x)\). La partie entière de ce nombre est le nombre de chiffres tout à fait exacts et la partie décimale donne une idée sur le fait que le chiffre suivant est plus ou moins bien.
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Problèmes pour écrire des nombres}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 \begin{remark}
-    Si nous voulons donner \( x\in \eR\) à un ordinateur, nous sommes soumis à deux erreurs :
-    \begin{enumerate}
-        \item
-            D'abord, vu que nous ne pouvons pas taper sur le clavier toutes les décimales de \( x\), nous faisons une \defe{erreur de troncature}{erreur!troncature}.
-        \item
-            L'ordinateur devant convertir cela en base deux, il commet une seconde erreur, dite \defe{erreur d'assignation}{erreur!assignation}.
-    \end{enumerate}
+	Si nous voulons donner \( x\in \eR\) à un ordinateur, nous sommes soumis à deux erreurs :
+	\begin{enumerate}
+		\item
+			D'abord, vu que nous ne pouvons pas taper sur le clavier toutes les décimales de \( x\), nous faisons une \defe{erreur de troncature}{erreur!troncature}.
+		\item
+			L'ordinateur devant convertir cela en base deux, il commet une seconde erreur, dite \defe{erreur d'assignation}{erreur!assignation}.
+	\end{enumerate}
 \end{remark}
 
 Supposons que nous voulions écrire le nombre (écrit ici en base \( 10\))
 \begin{equation}
-    0.4567894251
+	0.4567894251
 \end{equation}
 de façon plus facile à lire, on peut demander de ne laisser que \( t\) chiffres significatifs. Disons \( t=3\).
 
 \begin{description}
-    \item[Technique de troncature] On garde \( 3\) chiffres significatifs : \( 0.456\). Facile. 
-    \item[Technique d'arrondi] Vu que le premier qu'on supprime est un \( 7\), le dernier qu'on garde est majoré de \( 1\) : on écrit \( 0.457\).
+	\item[Technique de troncature] On garde \( 3\) chiffres significatifs : \( 0.456\). Facile.
+	\item[Technique d'arrondi] Vu que le premier qu'on supprime est un \( 7\), le dernier qu'on garde est majoré de \( 1\) : on écrit \( 0.457\).
 
 
 \end{description}
@@ -352,289 +351,289 @@ de façon plus facile à lire, on peut demander de ne laisser que \( t\) chiffre
 Si le premier chiffre rejeté est un \( 5\), il faut augmenter de \( 1\) de dernier chiffre gardé parce qu'il y a presque certainement encore un chiffre non nul derrière.
 
 \begin{remark}
-    Les ordinateurs travaillent tous en mode d'arrondi.
+	Les ordinateurs travaillent tous en mode d'arrondi.
 \end{remark}
 
 Si on doit entrer le nombre \( 0.38358546\) dans un ordinateur qui ne garde que \( 3\) chiffres significatifs, il faut entrer \( 0.384\) (erreur classique dans les exercices).
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Quelque bonnes règles}
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{enumerate}
-    \item
-        Si on a plusieurs nombres à additionner ou soustraire, il vaut mieux commencer par sommer ou soustraire ceux dont on sait qu'ils ont le même ordre de grandeur. Il n'y a donc pas tout à fait «associativité» des erreurs.
-    \item
-        Les opérations délicates sont l'addition et la soustraction. La multiplication et la division sont sans dangers, à part l'erreur de dépassement du maximum. Dans une multiplication, on perd au pire quelque chiffres significatifs, mais certainement les derniers, pas les premiers.
+	\item
+		Si on a plusieurs nombres à additionner ou soustraire, il vaut mieux commencer par sommer ou soustraire ceux dont on sait qu'ils ont le même ordre de grandeur. Il n'y a donc pas tout à fait «associativité» des erreurs.
+	\item
+		Les opérations délicates sont l'addition et la soustraction. La multiplication et la division sont sans dangers, à part l'erreur de dépassement du maximum. Dans une multiplication, on perd au pire quelque chiffres significatifs, mais certainement les derniers, pas les premiers.
 \end{enumerate}
 
-Soient deux nombres dont la différence d'ordre de grandeurs est plus grande que la précision de la machine. Alors de facto un des deux disparaît. 
+Soient deux nombres dont la différence d'ordre de grandeurs est plus grande que la précision de la machine. Alors de facto un des deux disparaît.
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
-\section{Erreur de «cancelation»}
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+\section{Erreur de ``cancellation''}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Lorsque deux nombres sont de même ordre de grandeur, avec plusieurs nombres significatifs identiques.
 
 \begin{example}
-    Soit à résoudre l'équation \( ax^2+bx+c=0\) avec \( a,b,c\neq 0\) et \( b^2-4ac>0\). Solution :
-    \begin{equation}
-        x_{1,2}=\frac{ -b\mp\sqrt{b^2-4ac} }{ 2a }.
-    \end{equation}
-    Note : on écrit \( \mp\) au lieu de \( \mp\) pour les classer dans l'ordre croissant, mais ce n'est pas crucial.
+	Soit à résoudre l'équation \( ax^2+bx+c=0\) avec \( a,b,c\neq 0\) et \( b^2-4ac>0\). Solution :
+	\begin{equation}
+		x_{1,2}=\frac{ -b\mp\sqrt{b^2-4ac} }{ 2a }.
+	\end{equation}
+	Note : on écrit \( \mp\) au lieu de \( \mp\) pour les classer dans l'ordre croissant, mais ce n'est pas crucial.
 
-    Supposons que \( | 4ac |\ll b^2\) avec tout de même pas tellement petit qu'on se perd dans la précision. Bref, on suppose que seules quelque dernières décimales de \( b^2-4ac\) sont différentes de zéro.
+	Supposons que \( | 4ac |\ll b^2\) avec tout de même pas tellement petit qu'on se perd dans la précision. Bref, on suppose que seules quelque dernières décimales de \( b^2-4ac\) sont différentes de zéro.
 
-    On a : 
-    \begin{subequations}
-        \begin{align}
-            \sqrt{b^2-4ac}&=\sqrt{\tilde b}= | \tilde b | \\
-            x_1&=\frac{ -b-\sqrt{b^2-4ac} }{ 2a }\\
-            x_2&=\frac{ -b+\sqrt{b^2-4ac} }{ 2a }
-        \end{align}
-    \end{subequations}
-    Si \( b>0\), nous avons une erreur de cancelation dans \( x_2\) parce qu'on fait la différence entre deux nombres presque égaux. Donc \( x_2\) mal calculé. Par contre \( x_1\) est bien calculé.
+	On a :
+	\begin{subequations}
+		\begin{align}
+			\sqrt{b^2-4ac}&=\sqrt{\tilde b}= | \tilde b | \\
+			x_1&=\frac{ -b-\sqrt{b^2-4ac} }{ 2a }\\
+			x_2&=\frac{ -b+\sqrt{b^2-4ac} }{ 2a }
+		\end{align}
+	\end{subequations}
+	Si \( b>0\), nous avons une erreur de ``cancellation'' dans \( x_2\) parce qu'on fait la différence entre deux nombres presque égaux. Donc \( x_2\) mal calculé. Par contre \( x_1\) est bien calculé.
 
-    Si par contre \( b<0\), c'est le contraire.
+	Si par contre \( b<0\), c'est le contraire.
 
 
-    Avec \( a=10^{-3}\), \( b=0.8\), \( c=-1.2\times 10^{-5}\). À la main nous obtenons : \( x_1=-800\), \( x_2=1.5\times 10^{-5}\), et un ordinateur se tromperait \ldots
-    
+	Avec \( a=10^{-3}\), \( b=0.8\), \( c=-1.2\times 10^{-5}\). À la main nous obtenons : \( x_1=-800\), \( x_2=1.5\times 10^{-5}\), et un ordinateur se tromperait \ldots
+
 
 \lstinputlisting{sageSnip001.sage}
 
-    Donc Sage ne tombe pas dans le piège.
+	Donc Sage ne tombe pas dans le piège.
 \end{example}
 
 Comment résoudre ce problème ? Ou, autre façon de poser la question : comment Sage a fait pour résoudre le problème ?
 
 Utilisons les relations coefficients-racines :
 \begin{subequations}
-    \begin{align}
-        x_1+x_2&=-b/a\\
-        x_1x_2&=c/a
-    \end{align}
+	\begin{align}
+		x_1+x_2&=-b/a\\
+		x_1x_2&=c/a
+	\end{align}
 \end{subequations}
 La première lie les deux racines par des opérations de addition et soustractions, et donc n'est pas intéressantes. La seconde est bien. Si nous connaissons \( x_1\), nous calculons
 \begin{equation}
-    x_2=\frac{ c }{ ax_1 }.
+	x_2=\frac{ c }{ ax_1 }.
 \end{equation}
 
 Quitte à redéfinir \( x_1\) et \( x_2\), la solution bien calculée est :
 \begin{equation}
-    x_1=\frac{ -b-\signe(b)\sqrt{b^2-4ac} }{ 2a }.
+	x_1=\frac{ -b-\signe(b)\sqrt{b^2-4ac} }{ 2a }.
 \end{equation}
 
 \begin{example}
-    Nous considérons :
-    \begin{equation}
-        f(x)=cos(x+\delta)-\cos(x).
-    \end{equation}
-    Cela a une erreur de cancellation lorsque \( | \delta |\ll | x |\). On élimine l'erreur de cancellation par
-    \begin{equation}
-        f(x)=-2\sin(\delta/2)\sin\left( x+\frac{ \delta }{ 2 } \right).
-    \end{equation}
+	Nous considérons :
+	\begin{equation}
+		f(x)=cos(x+\delta)-\cos(x).
+	\end{equation}
+	Cela a une erreur de ``cancellation'' lorsque \( | \delta |\ll | x |\). On élimine l'erreur de ``cancellation'' par
+	\begin{equation}
+		f(x)=-2\sin(\delta/2)\sin\left( x+\frac{ \delta }{ 2 } \right).
+	\end{equation}
 
-    \begin{probleme}
-        Pourquoi la condition pour avoir l'erreur est \( \delta\ll x\) et non simplement \( \delta\ll 1\) ?
-    \end{probleme}
+	\begin{probleme}
+		Pourquoi la condition pour avoir l'erreur est \( \delta\ll x\) et non simplement \( \delta\ll 1\) ?
+	\end{probleme}
 
 \end{example}
 
 \begin{example}
-    Pour
-    \begin{equation}
-        f(x)=\sqrt{x+\delta}-\sqrt{x}.
-    \end{equation}
-    On fait la coup du binôme conjugué :
-    \begin{equation}
-        f(x)=\frac{ \delta }{ \sqrt{x+\delta}+\sqrt{x} }.
-    \end{equation}
-    Plus d'erreur de cancellation, vu qu'au dénominateur nous avons une somme de deux positifs.
+	Pour
+	\begin{equation}
+		f(x)=\sqrt{x+\delta}-\sqrt{x}.
+	\end{equation}
+	On fait la coup du binôme conjugué :
+	\begin{equation}
+		f(x)=\frac{ \delta }{ \sqrt{x+\delta}+\sqrt{x} }.
+	\end{equation}
+	Plus d'erreur de ``cancellation'', vu qu'au dénominateur nous avons une somme de deux positifs.
 \end{example}
 
-Les erreurs de cancellation ne se résolvent pas en augmentant la précision des nombres donnés.
+Les erreurs de ``cancellation'' ne se résolvent pas en augmentant la précision des nombres donnés.
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Conditionnement et stabilité}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Ne pas confondre : 
+Ne pas confondre :
 \begin{description}
-    \item[Le conditionnement] provient du problème lui-même.
-    \item[La stabilité] provient de l'algorithme de résolution.
+	\item[Le conditionnement] provient du problème lui-même.
+	\item[La stabilité] provient de l'algorithme de résolution.
 \end{description}
 
 \begin{example}[Un problème mal conditionné]
-    Le système
-    \begin{subequations}
-        \begin{numcases}{}
-            2.1x+3.5y=8\\
-            4.19x+7.0y=15
-        \end{numcases}
-    \end{subequations}
-    Solution : \( x=100\), \( y=  -57.714285\cdots \) (périodique)
+	Le système
+	\begin{subequations}
+		\begin{numcases}{}
+			2.1x +  3.5y = 8 \\
+			4.19x + 7.0y = 15
+		\end{numcases}
+	\end{subequations}
+	Solution : \( x=100\), \( y=  -57.714285\cdots \) (périodique)
 
-    Perturbons : nous remplaçons \( 4.19\) par \( 4.192\). L'erreur relative est : \( 4.77\times 10^{-4}\).
+	Perturbons : nous remplaçons \( 4.19\) par \( 4.192\). L'erreur relative est : \( 4.77\times 10^{-4}\).
 
-    Solution : \( \bar x=125\), \( \bar y=-72.714285\cdots\), avec donc erreur relative de \( 0.26\). Autrement dit : l'erreur relative sur la solution est grande même avec une petite erreur relative sur la donnée.
+	Solution : \( \bar x=125\), \( \bar y=-72.714285\cdots\), avec donc erreur relative de \( 0.26\). Autrement dit : l'erreur relative sur la solution est grande même avec une petite erreur relative sur la donnée.
 
-    C'est un problème mal conditionné.
+	C'est un problème mal conditionné.
 
-    Le fait est que c'est une intersection de deux droites presque parallèles. Donc effectivement une petite perturbation d'une des deux droites donne une grande perturbation du point d'intersection.
+	Le fait est que c'est une intersection de deux droites presque parallèles. Donc effectivement une petite perturbation d'une des deux droites donne une grande perturbation du point d'intersection.
 
-    Le fait est qu'un ordinateur effectue \emph{toujours} une perturbation, au moins de l'ordre \( 10^{-16}\) pour ne fut-ce que représenter les nombres. C'est à dire une perturbation sur les six nombres. Il n'y a donc pas d'espoir d'obtenir un algorithme donnant une bonne réponse.
+	Le fait est qu'un ordinateur effectue \emph{toujours} une perturbation, au moins de l'ordre \( 10^{-16}\) pour ne fut-ce que représenter les nombres. C'est à dire une perturbation sur les six nombres. Il n'y a donc pas d'espoir d'obtenir un algorithme donnant une bonne réponse.
 \end{example}
 
 Solution, très approximativement : le problème est fondamentalement le fait que la matrice du système est de petit déterminant. Donc on peut tout multiplier par une matrice à gros déterminant, résoudre puis appliquer la matrice inverse.
 
 \begin{example}[Problème bien conditionné avec algorithme instable]
-    Soit à calculer 
-    \begin{equation}
-        I_n=\frac{1}{ e }\int_0^1x^ne^xdx
-    \end{equation}
-    avec \( n\geq 0\). Par partie, nous obtenons :
-    \begin{equation}
-        I_n=1-nI_{n-1}.
-    \end{equation}
-    D'autre part, \( I_0=\frac{ e-1 }{ e }\), \( I_1=\frac{1}{ e }\). Puis par récurrence, c'est tout en main.
+	Soit à calculer
+	\begin{equation}
+		I_n=\frac{1}{ e }\int_0^1x^ne^xdx
+	\end{equation}
+	avec \( n\geq 0\). Par partie, nous obtenons :
+	\begin{equation}
+		I_n=1-nI_{n-1}.
+	\end{equation}
+	D'autre part, \( I_0=\frac{ e-1 }{ e }\), \( I_1=\frac{1}{ e }\). Puis par récurrence, c'est tout en main.
 
-    Du côté de l'ordinateur, nous lui donnons forcément une approximation de \( I_1\), parce que nous lui donnons une approximation de \( e\). Soit l'erreur \( \epsilon_1\) sur \( I_1\). 
+	Du côté de l'ordinateur, nous lui donnons forcément une approximation de \( I_1\), parce que nous lui donnons une approximation de \( e\). Soit l'erreur \( \epsilon_1\) sur \( I_1\).
 
-    Sans démonstration :
-    \begin{lemma}
-        Nous avons \( \lim_{n\to \infty} I_n=0\)
-    \end{lemma}
-    Mais numériquement, il n'est pas possible de rester longtemps sous \( \epsilon_1\) parce que nous n'espérons pas avoir une erreur plus petite que ça. Donc à partir du moment où \( I_n<\epsilon_1\), les valeurs sont toutes complètement fausses. Cela est le mieux que l'on puisse espérer. Mais la réalité est pire.
+	Sans démonstration :
+	\begin{lemma}
+		Nous avons \( \lim_{n\to \infty} I_n=0\).
+	\end{lemma}
+	Mais numériquement, il n'est pas possible de rester longtemps sous \( \epsilon_1\) parce que nous n'espérons pas avoir une erreur plus petite que ça. Donc à partir du moment où \( I_n<\epsilon_1\), les valeurs sont toutes complètement fausses. Cela est le mieux que l'on puisse espérer. Mais la réalité est pire.
 
-    En réalité, en lançant le calcul sur un ordinateur, les valeurs sont même croissantes avec \( n\) à partir d'un certain moment.
+	En réalité, en lançant le calcul sur un ordinateur, les valeurs sont même croissantes avec \( n\) à partir d'un certain moment.
 
-    On peut étudier l'erreur et montrer que l'erreur est donnée par :
-    \begin{equation}
-        \epsilon_n=(-1)^{n-1}n!\epsilon_1.
-    \end{equation}
-    Mais comme la factorielle est tellement forte que c'est sans espoir d'aller loin en essayant très fort de donner une petite erreur sur \( \epsilon_1\).
+	On peut étudier l'erreur et montrer que l'erreur est donnée par :
+	\begin{equation}
+		\epsilon_n=(-1)^{n-1}n!\epsilon_1.
+	\end{equation}
+	Mais comme la factorielle est tellement forte que c'est sans espoir d'aller loin en essayant très fort de donner une petite erreur sur \( \epsilon_1\).
 
 \end{example}
 
 Il existe heureusement un algorithme stable pour cette intégrale. La formule est :
 \begin{equation}
-    I_{n-1}=\frac{1}{ n }(1-I_n).
+	I_{n-1}=\frac{1}{ n }(1-I_n).
 \end{equation}
 Si nous savons un \( I_N\) avec \( N\) grand, cette formule donne les \( I_i\) avec \( i=N,N-1,\ldots, 2\). Posons donc \( I_N=a\in \eR\) n'importe comment. Donc \( \epsilon_N\) est grand. Mais il se trouve que l'erreur sur \( \epsilon_1\) est donnée par
 \begin{equation}
-    \epsilon_1=\frac{ (-1)^{N-1} }{ N! }\epsilon_N.
+	\epsilon_1=\frac{ (-1)^{N-1} }{ N! }\epsilon_N.
 \end{equation}
 Donc même en prenant vraiment n'importe quoi pour \( I_N\), nous obtenons de bonnes approximations pour \( I_i\) avec les petits \( i\). Même avec \( I_{20}=1000\) (qui est complètement faux), nous trouvons énormément de chiffres significatifs corrects pour \( I_1\).
 
 \begin{exercice}
-    Soient les expressions (algébriquement égales) :
-    \begin{enumerate}
-        \item
-            \(A= x(x+1)\)
-        \item
-            \(B= x^2+x\)
-    \end{enumerate}
-    Nous savons que 
-    \begin{equation}
-        x=\fl(x)=10^{-30}
-    \end{equation}
-    et
-    \begin{equation}
-        1=\fl(1)
-    \end{equation}
-    parce que pour \( 1\) et \( 10^{-30}\), il n'y a pas d'erreurs d'assignation.
+	Soient les expressions (algébriquement égales) :
+	\begin{enumerate}
+		\item
+			\(A= x(x+1)\)
+		\item
+			\(B= x^2+x\)
+	\end{enumerate}
+	Nous savons que
+	\begin{equation}
+		x=\fl(x)=10^{-30}
+	\end{equation}
+	et
+	\begin{equation}
+		1=\fl(1)
+	\end{equation}
+	parce que pour \( 1\) et \( 10^{-30}\), il n'y a pas d'erreurs d'assignation.
 
-    En précision simple, \( 10^{-30}+1=1\) parce qu'en précision simple, il n'y a que \( 7\) ou \( 8\) chiffres significatifs\footnote{Erreur de « relation normale».}.
+	En précision simple, \( 10^{-30}+1=1\) parce qu'en précision simple, il n'y a que \( 7\) ou \( 8\) chiffres significatifs\footnote{Erreur de « relation normale».}.
 
-    Nous avons $A=10^{-30}$, mais \( x^2\) donne un \info{underflow} parce que \( 10^{-60}\) ne peut pas être représenté en précision simple. En pratique, beaucoup de logiciels en font \( 0\). Dans ce cas, en réalité \( B\) donne effectivement \( 10^{-30}\) après avoir fait \( x^2+x=0+x=10^{-30}\).
+	Nous avons $A=10^{-30}$, mais \( x^2\) donne un \info{underflow} parce que \( 10^{-60}\) ne peut pas être représenté en précision simple. En pratique, beaucoup de logiciels en font \( 0\). Dans ce cas, en réalité \( B\) donne effectivement \( 10^{-30}\) après avoir fait \( x^2+x=0+x=10^{-30}\).
 \end{exercice}
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Équations non linéaire}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Certains équations non linéaires sont résoluble explicitement, par exemples les polynômes de degré jusqu'à \( 4\) ou des choses comme
 \begin{equation}
-    \sin^2(x)+3\sin(x)+5=0.
+	\sin^2(x)+3\sin(x)+5=0.
 \end{equation}
 Mais ces exemples sont très rares.
 
-Nous allons étudier des équations du type \( f(x)=0\), dans \( \eR\). 
+Nous allons étudier des équations du type \( f(x)=0\), dans \( \eR\).
 
 \begin{enumerate}
-    \item
+	\item
 Un problème écrit sous la forme \( x=g(x)\) peut utiliser des théorèmes de points fixes.
 \item
-    Un problème sous la forme \( f(x)=0\) peut utiliser des méthodes de bisection, Newton ou autres.
+	Un problème sous la forme \( f(x)=0\) peut utiliser des méthodes de bisection, Newton ou autres.
 \end{enumerate}
 Il y a évidemment beaucoup de façons de transformer un problème pour passer d'une forme à l'autre.
 
 \begin{example}
-    Soit \( f(x)=x^2-a=0\) avec \( a>0\). Nous pouvons l'écrire
-    \begin{equation}
-        x^2+x-a=x
-    \end{equation}
-    qui donne une forme \( g(x)=x\) pour \( g(x)=x^2+x-a\).
+	Soit \( f(x)=x^2-a=0\) avec \( a>0\). Nous pouvons l'écrire
+	\begin{equation}
+		x^2+x-a=x
+	\end{equation}
+	qui donne une forme \( g(x)=x\) pour \( g(x)=x^2+x-a\).
 
-    Ou encore \( x=\frac{ a }{ x }\) et donc \( g(x)=a/x\) (si par ailleurs on sait que \( x\neq 0\)). Notons que \( x\neq 0\) n'est pas une hypothèse très forte parce qu'on la vérifie directement sur \( a\).
+	Ou encore \( x=\frac{ a }{ x }\) et donc \( g(x)=a/x\) (si par ailleurs on sait que \( x\neq 0\)). Notons que \( x\neq 0\) n'est pas une hypothèse très forte parce qu'on la vérifie directement sur \( a\).
 \end{example}
 
 \begin{example}
-    Soit l'équation à résoudre
-    \begin{equation}
-        f(x)=x^2-2-\ln(x)=0
-    \end{equation}
-    Les solutions de cette équations peuvent être vues comme les intersections avec l'axe \( X\) du graphe \( y=x^2-2-\ln(x)\). Tracer peut donc aider. Par ailleurs, il faut noter que
-    \begin{equation}
-        \lim_{x\to \pm\infty} f(x)=\infty,
-    \end{equation}
-    donc les solutions sont certainement contenues dans un compact de \( \eR\).
+	Soit l'équation à résoudre
+	\begin{equation}
+		f(x)=x^2-2-\ln(x)=0
+	\end{equation}
+	Les solutions de cette équations peuvent être vues comme les intersections avec l'axe \( X\) du graphe \( y=x^2-2-\ln(x)\). Tracer peut donc aider. Par ailleurs, il faut noter que
+	\begin{equation}
+		\lim_{x\to \pm\infty} f(x)=\infty,
+	\end{equation}
+	donc les solutions sont certainement contenues dans un compact de \( \eR\).
 
-    À part tracer nous pouvons écrire
-    \begin{equation}
-        x^2-2=\ln(x).
-    \end{equation}
-    Et là, ce sont deux fonctions dont nous pouvons tracer le graphe pour trouver graphiquement les points d'intersection. Une étude de fonction montre vite qu'il y a exactement deux solutions, qu'elles sont strictement positives. Pour trouver des bornes, il faut calculer par exemple pour \( x=2\) les valeurs de \( \ln(x)\) et \( x^2-2\) pour voir si le graphe de \( x^2-2\) est déjà plus haut.
+	À part tracer nous pouvons écrire
+	\begin{equation}
+		x^2-2=\ln(x).
+	\end{equation}
+	Et là, ce sont deux fonctions dont nous pouvons tracer le graphe pour trouver graphiquement les points d'intersection. Une étude de fonction montre vite qu'il y a exactement deux solutions, qu'elles sont strictement positives. Pour trouver des bornes, il faut calculer par exemple pour \( x=2\) les valeurs de \( \ln(x)\) et \( x^2-2\) pour voir si le graphe de \( x^2-2\) est déjà plus haut.
 \end{example}
 
 La majorité des méthodes numériques de résolution d'équation du type \( f(x)=0\) ou \( x=g(x)\) seront sous la forme de suites. Avec questions à la clefs :
 \begin{enumerate}
-    \item
-        Quel point de départ choisir ?
-    \item
-        Convergence ?
-    \item
-        Est-ce que la limite est bien une solution ?
-    \item
-        Vu que la limite est unique, comment faire si l'équation a plusieurs solutions ? (souvent c'est le choix du point initial qui va jouer sur ce point)
+	\item
+		Quel point de départ choisir ?
+	\item
+		Convergence ?
+	\item
+		Est-ce que la limite est bien une solution ?
+	\item
+		Vu que la limite est unique, comment faire si l'équation a plusieurs solutions ? (souvent c'est le choix du point initial qui va jouer sur ce point)
 \end{enumerate}
 
 \begin{normaltext}
-    Si la fonction est très plate, il est possible d'avoir
-    \begin{equation}
-        | f(\tilde \alpha) |\leq \epsilon
-    \end{equation}
-    sans que \( \tilde \alpha\) ne soit une bonne approximation.
+	Si la fonction est très plate, il est possible d'avoir
+	\begin{equation}
+		| f(\tilde \alpha) |\leq \epsilon
+	\end{equation}
+	sans que \( \tilde \alpha\) ne soit une bonne approximation.
 
-    Lorsqu'on fait tourner une méthode itérative résolvant \( f(x)=0\), il n'est pas suffisant de s'arrêter lorsque
-    \begin{equation}
-        f(x_n)\leq \epsilon_1.
-    \end{equation}
-    Il faut aussi s'assurer que, si \( \bar x\) est la solution exacte, \( | x_n-\bar x |\leq \epsilon_2\). Ici \( \epsilon_1\) et \( \epsilon_2\) sont deux «précisions» que nous nous fixons au départ.
+	Lorsqu'on fait tourner une méthode itérative résolvant \( f(x)=0\), il n'est pas suffisant de s'arrêter lorsque
+	\begin{equation}
+		f(x_n)\leq \epsilon_1.
+	\end{equation}
+	Il faut aussi s'assurer que, si \( \bar x\) est la solution exacte, \( | x_n-\bar x |\leq \epsilon_2\). Ici \( \epsilon_1\) et \( \epsilon_2\) sont deux «précisions» que nous nous fixons au départ.
 
-    Évidemment, vérifier la condition \( | x_n-\bar x |\leq \epsilon_2\), il faudrait savoir \( \bar x\). Et savoir \( \bar x\) c'est justement le problème. Nous sommes donc amenés à faire des estimation de \( | x_n-\bar x |\).
+	Évidemment, vérifier la condition \( | x_n-\bar x |\leq \epsilon_2\), il faudrait savoir \( \bar x\). Et savoir \( \bar x\) c'est justement le problème. Nous sommes donc amenés à faire des estimation de \( | x_n-\bar x |\).
 \end{normaltext}
 
 Soit \( p\) l'ordre de convergence de la suite \( (x_n)\) vers \( \bar x\). Si \( p>1\) et \( | x_{n+1}-x_n |\leq \epsilon_2\) alors \( | \bar x-x_n |\leq \epsilon_2\).
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Méthode de bisection}
 %---------------------------------------------------------------------------------------------------------------------------
 
 Il y a ce théorème des valeurs intermédiaires.
 \begin{theorem}
-    Soit \( f\) continue sur \( \mathopen[ a , b \mathclose]\) telle que \( f(a)f(b)<0\). Alors il existe au moins une solution à l'équation \( f(x)=0\) sur l'intervalle \( \mathopen] a , b \mathclose[\).
+	Soit \( f\) continue sur \( \mathopen[ a , b \mathclose]\) telle que \( f(a)f(b)<0\). Alors il existe au moins une solution à l'équation \( f(x)=0\) sur l'intervalle \( \mathopen] a , b \mathclose[\).
 \end{theorem}
 
 Pour démarrer une bisection, il est toujours bon de prendre l'intervalle \( \mathopen[ a , b \mathclose]\) de façon à ne contenir qu'une seule solution.
@@ -643,11 +642,11 @@ Soit donc un premier intervalle \( \mathopen[ a_0 , b_O \mathclose]\) tel que \(
 
 Le test d'arrêt de la méthode de bisection se base uniquement sur la taille de l'intervalle qui reste. En effet si nous avons
 \begin{equation}
-    | b_n-a_n |\leq \epsilon
+	| b_n-a_n |\leq \epsilon
 \end{equation}
 nous avons certainement
 \begin{equation}
-    | \bar x-x_n |\leq \frac{ \epsilon }{2}
+	| \bar x-x_n |\leq \frac{ \epsilon }{2}
 \end{equation}
 où \( x_n\) est le point du milieu de \( \mathopen[ a_n , b_n \mathclose]\).
 


### PR DESCRIPTION
- [X] Meilleur ordonnancement des lignes dans le ``.gitignore`` (et ajout de règles ``*~`` plutôt que ``makefile~``);
- [X] Rapide relecture du contenu de 145_theorie.tex, super;
- [ ] Il reste des \(..\) qui pourraient/devraient être changées en $..$ ?
- [ ] Pareil, est-ce que ``«..»`` → ``..'' ou pas ?
- [X] OK pour les exemples (pas vérifié le code Sage inclut par contre).