### PR TITLE
Typos on 82_analyse_fonctionnelle.tex

### DIFF
--- a/82_analyse_fonctionnelle.tex
+++ b/82_analyse_fonctionnelle.tex
@@ -3,12 +3,12 @@
 %   Laurent Claessens
 % See the file fdl-1.3.txt for copying conditions.
 
-Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui dit que si \( \int f=0\) c'est que \( f=0\) dans un sens ou dans un autre. 
+Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui dit que si \( \int f=0\) c'est que \( f=0\) dans un sens ou dans un autre.
 \begin{enumerate}
     \item
         Il y a le lemme \ref{Lemfobnwt} qui dit ça.
     \item
-        Un lemme du genre dans \( L^2\) existe aussi pour \( \int f\varphi=0\) pour tout \( \varphi\). C'est le lemme \ref{LemDQEKNNf}. 
+        Un lemme du genre dans \( L^2\) existe aussi pour \( \int f\varphi=0\) pour tout \( \varphi\). C'est le lemme \ref{LemDQEKNNf}.
     \item
         Et encore un pour \( L^p\) dans la proposition \ref{PropUKLZZZh}.
     \item
@@ -34,7 +34,7 @@ Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui 
 \index{théorème!isomorphisme de Banach}
 % TODO : une preuve.
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Théorème d'Ascoli}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -59,7 +59,7 @@ Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui 
 \end{definition}
 
 \begin{definition}  \label{DefUWmVBcZ}
-    Soit \( (f_i)_{i\in I}\) une famille de fonctions \( f_i\colon X\to Y\) entre espaces métriques. Cette famille est \defe{équicontinue}{equicontinuite@équicontinuité} si pour tout \( \epsilon>0\) et pour tout \( x\in X\), il existe un \( \delta(x,\epsilon)>0\) tel que 
+    Soit \( (f_i)_{i\in I}\) une famille de fonctions \( f_i\colon X\to Y\) entre espaces métriques. Cette famille est \defe{équicontinue}{equicontinuite@équicontinuité} si pour tout \( \epsilon>0\) et pour tout \( x\in X\), il existe un \( \delta(x,\epsilon)>0\) tel que
     \begin{equation}
         \| x-y \|_X\leq \delta\,\Rightarrow\,\| f_i(x)-f_i(y) \|_Y\leq \epsilon
     \end{equation}
@@ -78,7 +78,7 @@ Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui 
 \index{théorème!Ascoli}
 %TODO : une preuve est sur Wikipédia.
 
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
+%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Théorème de Banach-Steinhaus}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -89,20 +89,20 @@ Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui 
 \index{application!linéaire!théorème de Banach-Steinhaus}
 
 \begin{proof}
-    
+
     Si \( H\) est uniformément borné, il est borné; pas besoin de rester longtemps sur ce sens de l'équivalence. Supposons donc que \( H\) soit borné. Pour chaque \( k\in \eN^*\) nous considérons l'ensemble
     \begin{equation}
         \Omega_k=\{ x\in E\tq \sup_{f\in H}\| f(x) \|>k \}.
     \end{equation}
-    
+
     \begin{subproof}
         \item[Les \( \Omega_k\) sont ouverts]
-            
+
             Soit \( x_0\in \Omega_k\); nous avons alors une fonction \( f\in H\) telle que \(  \| f(x_0) \|>k \), et par continuité de \( f\) il existe \( \rho>0\) tel que \( \| f(x) \|>k\) pour tout \( x\in B(x_0,\rho)\). Par conséquent \( B(x_0,\rho)\subset \Omega_k\) et \( \Omega_k\) est ouvert par le théorème \ref{ThoPartieOUvpartouv}.
 
         \item[Les \( \Omega_k\) ne sont pas tous denses dans \( E\)]
 
-            Nous supposons que les ensembles \( \Omega_k\) soient tous dense dans \( E\). Le théorème de Baire \ref{ThoBBIljNM} nous indique que \( E\) est un espace de Baire (parce que de Banach) et donc que 
+            Nous supposons que les ensembles \( \Omega_k\) soient tous dense dans \( E\). Le théorème de Baire \ref{ThoBBIljNM} nous indique que \( E\) est un espace de Baire (parce que de Banach) et donc que
             \begin{equation}
                 \overline{ \bigcap_{k\in \eN}\Omega_k }=E.
             \end{equation}
@@ -111,10 +111,10 @@ Bonjour. Si vous êtes ici, c'est sans doute que vous cherchez le résultat qui 
                 \sup_{f\in H}\| f(x) \|=\infty,
             \end{equation}
             ce qui est contraire à l'hypothèse. Donc les ouverts \( \Omega_k\) ne sont pas tous denses dans \(E\).
-            
+
         \item[La majoration]
 
-            Il existe \( k\geq 0\) tel que \( \Omega_k\) ne soit pas dense dans \( E\), et nous voulons prouver que \( \{ \| f \|\tq f\in H \}\) est un ensemble borné. Soit donc \( k\geq 0\) tel que \( \Omega_k\) ne soit pas dense dans \( E\); il existe un \( x_0\in E\) et \( \rho>0\) tels que 
+            Il existe \( k\geq 0\) tel que \( \Omega_k\) ne soit pas dense dans \( E\), et nous voulons prouver que \( \{ \| f \|\tq f\in H \}\) est un ensemble borné. Soit donc \( k\geq 0\) tel que \( \Omega_k\) ne soit pas dense dans \( E\); il existe un \( x_0\in E\) et \( \rho>0\) tels que
             \begin{equation}
                 B(x_0,\rho)\cap \Omega_k=\emptyset.
             \end{equation}
@@ -225,7 +225,7 @@ La version suivante du théorème de Banach-Steinhaus est énoncée de façon \e
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \label{SecVKiVIQK}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Généralités}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -240,7 +240,7 @@ et nous notons \( \mL^p(\Omega,\mu)\)\nomenclature[Y]{\( \mL^p\)}{espace de Lebe
 \begin{lemma}
     L'ensemble \( \mL^p\) est un espace vectoriel.
 \end{lemma}
-    
+
 \begin{proof}
     Le fait que si \( f\in L^p\), alors \( \lambda f\in L^p\) est évident. Ce qui est moins immédiat, c'est le fait que \( f+g\in L^p\) lorsque \( f\) et \( g\) sont dans \( L^p\). Cela découle du fait que la fonction \( \varphi\colon x\mapsto x^p\) est convexe, de telle sorte que
     \begin{equation}
@@ -292,7 +292,7 @@ Dans la suite nous n'allons pas toujours écrire \( [f]\) pour la classe de \( f
 \index{limite!inversion}
 
 \begin{proof}
-    Si \( p=\infty\) nous sommes en train de parler de la convergence uniforme et il ne faut même pas prendre ni de sous-suite ni de «presque partout».
+    Si \( p=\infty\) nous sommes en train de parler de la convergence uniforme et il ne faut même pas prendre ni de sous-suite ni de « presque partout ».
 
     Supposons que \( 1\leq p<\infty\). Nous considérons une sous-suite \( [h_n]\) de \( [f_n]\) telle que
     \begin{equation}
@@ -317,7 +317,7 @@ Dans la suite nous n'allons pas toujours écrire \( [f]\) pour la classe de \( f
 Est-ce qu'on peut faire mieux que la convergence ponctuelle presque partout d'une sous-suite ? En tout cas on ne peut pas espérer grand chose comme convergence pour la suite elle-même, comme le montre l'exemple suivant.
 
 \begin{example} \label{ExPOmxICc}
-    Nous allons montrer une suite de fonctions qui converge vers zéro dans \( L^p[0,1]\) (avec \( p<\infty\)) mais qui ne converge ponctuellement pour \emph{aucun} point. Cet exemple provient de \href{http://www.bibmath.net/dico/index.php?action=affiche&quoi=./b/bosseglissante.html}{bibmath.net}. 
+    Nous allons montrer une suite de fonctions qui converge vers zéro dans \( L^p[0,1]\) (avec \( p<\infty\)) mais qui ne converge ponctuellement pour \emph{aucun} point. Cet exemple provient de \href{http://www.bibmath.net/dico/index.php?action=affiche&quoi=./b/bosseglissante.html}{bibmath.net}.
 
 %TODO : revoir tous les \href et mettre ceux qui doivent être en bibliographie. Par exemple celui ci-dessus.
 
@@ -348,7 +348,7 @@ La proposition suivante est une espèce de convergence dominée de Lebesgue pour
    \end{equation}
 \end{proof}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{L'espace \texorpdfstring{$ L^{\infty}$}{Linfinity}}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -365,7 +365,7 @@ Nous posons alors \( N_{\infty}(f)=\inf\{ M\tq | f(x) |\leq M\text{ presque part
 \end{equation}
 et \( L^{\infty}\) en est le quotient usuel. Dans ce contexte nous notons \( \| f \|_{\infty}\) le supremum essentiel de \( f\), qui est indépendant de la classe.
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Inégalité de Jensen, Hölder et de Minkowski}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -423,7 +423,7 @@ et \( L^{\infty}\) en est le quotient usuel. Dans ce contexte nous notons \( \| 
     \end{equation}
 \end{proposition}
 \index{inégalité!Hölder}
-Ce qui est appelé «inégalité de Hölder» est généralement l'inéquation \eqref{EqLPKooPBCQYN}.
+Ce qui est appelé « inégalité de Hölder » est généralement l'inéquation \eqref{EqLPKooPBCQYN}.
 
 \begin{proof}
     Nous allons prouver l'inégalité \eqref{EqAVZooFNyzmT}. D'abord nous supposons \( \| g \|_q=1\) et nous posons
@@ -497,7 +497,7 @@ La partie \ref{ItemDHukLJiii} est une généralisation de l'inégalité triangul
     \left[ \int_X\Big( \int_Y| f(x,y) |d\nu(y) \Big)^pd\mu(x) \right]^{1/p}\leq \int_Y\Big( \int_X| f(x,y) |^pd\mu(x) \Big)^{1/p}d\nu(y).
 \end{equation}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Ni inclusions ni inégalités}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -542,7 +542,7 @@ Nous allons donner des exemples de tout ça en supposant \( p<q\) et en nous app
             \| f \|_q^q=\int_1^{\infty}\frac{1}{ x^{q/p} }dx<\infty.
         \end{equation}
 
-    \item[Exempe de \( \| f \|_p>\| f \|_q\)]
+    \item[Exemple de \( \| f \|_p>\| f \|_q\)]
 
         La fonction
         \begin{equation}
@@ -561,8 +561,8 @@ Nous allons donner des exemples de tout ça en supposant \( p<q\) et en nous app
         Mais comme \( p<q\) donc \( \| f \|_p>\| f \|_q\).
 
 
-    \item[Exempe de \( \| f \|_p<\| f \|_q\)]
-        
+    \item[Exemple de \( \| f \|_p<\| f \|_q\)]
+
         La fonction
         \begin{equation}
             f(x)=\begin{cases}
@@ -626,7 +626,7 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
     et \( \| f \|_p=\int_0^1\frac{1}{ x^{p/2} }<\infty\) parce que \( 1<p<2\).
 \end{remark}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Complétude}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -727,7 +727,7 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
     \begin{equation}
         | f_m(x)-f_n(x) |\leq\frac{1}{ k },
     \end{equation}
-    et si nous posons \( E=\bigcup_{k\in \eN}E_k\), nous avons encore un ensemble de mesure nulle (lemme \ref{LemIDITgAy}). En  résumé, nous avons un \( N_k\) tel que si \( m,n\geq N_k\), alors 
+    et si nous posons \( E=\bigcup_{k\in \eN}E_k\), nous avons encore un ensemble de mesure nulle (lemme \ref{LemIDITgAy}). En  résumé, nous avons un \( N_k\) tel que si \( m,n\geq N_k\), alors
     \begin{equation}    \label{EqKAWSmtG}
         | f_n(x)-f_m(x) |\leq \frac{1}{ k }
     \end{equation}
@@ -735,7 +735,7 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
     \begin{equation}
         \begin{aligned}
             f\colon \Omega\setminus E&\to \eR \\
-            x&\mapsto \lim_{n\to \infty} f_n(x). 
+            x&\mapsto \lim_{n\to \infty} f_n(x).
         \end{aligned}
     \end{equation}
     Cela prouve le point \ref{ItemPDnjOJzi} : la convergence ponctuelle.
@@ -780,7 +780,7 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
         \begin{equation}
             \begin{aligned}
                 f\colon \Omega\setminus E&\to \eR \\
-                x&\mapsto \lim_{n\to \infty} f_{\varphi(n)}(x) 
+                x&\mapsto \lim_{n\to \infty} f_{\varphi(n)}(x)
             \end{aligned}
         \end{equation}
         où \( E\) est de mesure nulle. Montrons que \( f\) est bien dans \( L^p(\Omega)\); pour cela nous complétons la série d'inégalités \eqref{EqWTHojCq} en
@@ -798,8 +798,8 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
                 f_{\varphi(n)}(x)&\leq | f(x) |+| g(x) |.
             \end{align}
         \end{subequations}
-        
-        La première inégalité assure que \( | f |^p\) est intégrable sur \( \Omega\setminus E\) parce que \( | f |\) est majorée par \( | g |+| f_{\varphi(n)} |\). Elle prouve par conséquent le point \ref{ItemPDnjOJzi} parce que \(n\mapsto f_{\varphi(n)}\) est une sous-suite convergente presque partout. La seconde montre le point \ref{ItemPDnjOJzii}. 
+
+        La première inégalité assure que \( | f |^p\) est intégrable sur \( \Omega\setminus E\) parce que \( | f |\) est majorée par \( | g |+| f_{\varphi(n)} |\). Elle prouve par conséquent le point \ref{ItemPDnjOJzi} parce que \(n\mapsto f_{\varphi(n)}\) est une sous-suite convergente presque partout. La seconde montre le point \ref{ItemPDnjOJzii}.
 
         Attention : à ce point nous avons prouvé que \( n\mapsto f_{\varphi(n)}\) est une suite de fonctions qui converge \emph{ponctuellement presque partout} vers une fonction \( f\) qui s'avère être dans \( L^p\). Nous n'avons pas montré que cette suite convergeait au sens de \( L^p\) vers \( f\). Ce que nous devons montrer est que
         \begin{equation}    \label{EqJLfnEvj}
@@ -821,7 +821,7 @@ Ces exemples donnent un exemple de fonction \( f\) telle que \( \| f \|_p<\| f \
     \end{subproof}
 \end{proof}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{L'espace \texorpdfstring{$L^2$}{$L^2$}}
 %---------------------------------------------------------------------------------------------------------------------------
 \label{subSecCKZSrZK}
@@ -840,7 +840,7 @@ Nous considérons l'ensemble
 \begin{equation}
     \mL^2(\Omega,\mu)=\{ f\colon \Omega\to \eR\tq \| f \|_2<\infty \}
 \end{equation}
-et la relation d'équivalence \( f\sim g\) si et seulement si \( f(x)=g(x)\) pour \( \mu\)-presque tout \( x\). 
+et la relation d'équivalence \( f\sim g\) si et seulement si \( f(x)=g(x)\) pour \( \mu\)-presque tout \( x\).
 
 \begin{definition}      \label{DEFooSVCHooIwwuIx}
     Nous définissons le quotient
@@ -894,7 +894,7 @@ Nous notons ici une conséquence du théorème \ref{ThoGVmqOro} dans le cas de l
     Par hypothèse le membre de droite est \( | s_m-s_n |\) où \( s_k\) dénote la suite des somme partielle de la série des \( | a_k |^2\). Cette dernière est de Cauchy (parce que convergente dans \( \eR\)) et donc la limite \( n\to\infty\) (en gardant \( m>n\)) est zéro. Donc la suite des \( f_n\) est de Cauchy dans \( L^2\) et donc converge dans \( L^2\).
 \end{proof}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Coefficients et série de Fourier}
 %---------------------------------------------------------------------------------------------------------------------------
 \label{subSecXAYasNI}
@@ -918,7 +918,7 @@ est une base hilbertienne de \( L^2\mathopen[ -T/2 , T/2 \mathclose]\) et que
     c_n(f)=\langle f, e_n\rangle .
 \end{equation}
 
-Nous pouvons être plus précis. Pour un élément donné \( f\in L^2\big( \mathopen[ 0 , 2\pi \mathclose] \big)\), nous définissons\nomenclature[Y]{\( S_nf\)}{somme partielle de série de Fourier} 
+Nous pouvons être plus précis. Pour un élément donné \( f\in L^2\big( \mathopen[ 0 , 2\pi \mathclose] \big)\), nous définissons\nomenclature[Y]{\( S_nf\)}{somme partielle de série de Fourier}
 \begin{equation}
     S_nf=\sum_{k=-n}^n\langle f, e_k\rangle e_k
 \end{equation}
@@ -958,7 +958,7 @@ Si nous voulons une vraie convergence ponctuelle voir uniforme \( (S_nf)(x)\to f
 Le théorème qui permet de définir le produit de convolution est la suivant.
 
 \begin{theoremDef}[\cite{MesIntProbb}]     \label{THOooMLNMooQfksn}
-    Soient \( f,g\in L^1(\eR^n)\). 
+    Soient \( f,g\in L^1(\eR^n)\).
     \begin{enumerate}
         \item
             Pour presque tout \( x\in \eR^n\), la fonction
@@ -1024,7 +1024,7 @@ Cette proposition est une conséquence de l'inégalité de Minkowski sous forme 
     Il s'agit d'itérer la proposition \ref{PropHNbdMQe}.
 \end{proof}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Densité des fonctions infiniment dérivables à support compact}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -1058,7 +1058,7 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
         \item
             Les fonctions étagées par rapport à \( L^p\) sur \( \eR^d\) sont denses dans \( L^p(\eR^d)\). A fortiori les fonctions étagées sont denses dans \( L^p\), mais nous n'en aurons pas besoin ici.
         \item\label{ItemYVFVrOIii}
-            Il existe une suite \( f_n\) dans \(  C(K,\eC)\) telle que 
+            Il existe une suite \( f_n\) dans \(  C(K,\eC)\) telle que
             \begin{equation}
                 f_n\stackrel{L^p}{\to}\mtu_{D}.
             \end{equation}
@@ -1068,7 +1068,7 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
                 \mtu_{D_n}\stackrel{L^p}{\to}\mtu_A.
             \end{equation}
         \item\label{ItemYVFVrOIiv}
-            Il existe une suite \( \varphi_n\) dans \(  C^{\infty}_c(\eR^d)\) telle que 
+            Il existe une suite \( \varphi_n\) dans \(  C^{\infty}_c(\eR^d)\) telle que
             \begin{equation}
                 \varphi_n\stackrel{L^p}{\to}\mtu_{D}.
             \end{equation}
@@ -1093,10 +1093,10 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
            C'est le théorème d'approximation \ref{ThoAFXXcVa} appliqué au borélien \( D\) contenu dans l'espace mesuré \( K\).
 
        \item
-            
-           En vertu du point \ref{ItemYVFVrOIii}, il existe \( f\in C^0(K,\eR)\) telle que 
+
+           En vertu du point \ref{ItemYVFVrOIii}, il existe \( f\in C^0(K,\eR)\) telle que
            \begin{equation}
-             \| f-\mtu_D \|_p\leq \epsilon. 
+             \| f-\mtu_D \|_p\leq \epsilon.
            \end{equation}
            Ensuite, par le théorème de Weierstrass, il existe \( \varphi\in C^{\infty}(K,\eR)\) telle que \( \| f-\varphi \|_{\infty}\leq \epsilon\). Nous avons aussi
            \begin{equation}
@@ -1137,12 +1137,12 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
            \begin{equation}
                \| \varphi_k-\mtu_{D_k} \|_p\leq \epsilon.
            \end{equation}
-           
+
            Il n'est pas compliqué de calculer que
            \begin{equation}
                \big\| \sum_{k=1}^Nc_k\varphi_k-f \big\|_p\leq 2\epsilon\sum_kc_k+\epsilon.
            \end{equation}
-        
+
    \end{enumerate}
 \end{proof}
 
@@ -1156,7 +1156,7 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
 \end{proof}
 
 \begin{lemma}       \label{LemDQEKNNf}
-    Soit \( f\in L^2(I)\) telle que 
+    Soit \( f\in L^2(I)\) telle que
     \begin{equation}
         \int_If\varphi=0
     \end{equation}
@@ -1168,7 +1168,7 @@ Le contraire n'est pas vrai : la fonction étagée sur \( \eR\) qui vaut \( n\) 
     \begin{equation}
         \begin{aligned}
             \phi\colon L^2(I)&\to \eC \\
-            g&\mapsto \langle f, g\rangle=\int_If\bar g . 
+            g&\mapsto \langle f, g\rangle=\int_If\bar g .
         \end{aligned}
     \end{equation}
     Par densité\footnote{Théorème \ref{ThoILGYXhX}\ref{ItemYVFVrOIv}.} nous pouvons aussi considérer une suite \( (\varphi_n)\) dans \(  C^{\infty}_c(I)\) convergent vers \( f\) dans \( L^2\). Alors nous avons pour tout \( n\) :
@@ -1190,7 +1190,7 @@ Ce résultat est encore valable dans les espaces \( L^p\) (proposition \ref{Prop
     \end{equation}
 \end{lemma}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Dualité et théorème de représentation de Riesz}
 %---------------------------------------------------------------------------------------------------------------------------
 \index{dual!espaces \( L^p\)}
@@ -1222,7 +1222,7 @@ Dans la suite \( E'\) est le dual topologique, c'est à dire l'espace des formes
 \end{proof}
 
 \begin{proposition}[\cite{PAXrsMn}] \label{PropOAVooYZSodR}
-    Soit \( 1<p<2\) et \( q\) tel que \( \frac{1}{ p }+\frac{1}{ q }=1\). L'application 
+    Soit \( 1<p<2\) et \( q\) tel que \( \frac{1}{ p }+\frac{1}{ q }=1\). L'application
     \begin{equation}
         \begin{aligned}
             \Phi\colon L^q\big( \mathopen[ 0 , 1 \mathclose] \big)&\to  L^p\big( \mathopen[ 0 , 1 \mathclose] \big)'  \\
@@ -1273,7 +1273,7 @@ Dans la suite \( E'\) est le dual topologique, c'est à dire l'espace des formes
             \begin{subproof}
 
                 \item[\( \phi\in (L^2)'\)]
-                
+
                     Nous devons montrer que \( \phi\) est continue pour la norme sur \( L^2\). Pour cela nous montrons que sa norme opérateur (subordonnée à la norme de \( L^2\) et non de \( L^p\)) est finie :
                     \begin{equation}
                         \sup_{f\in L^2}\frac{ | \phi(f) | }{ \| f \|_{2} }\leq \sup_{f\in L^2}\frac{ | \ell(f) | }{ \| f \|_p }<\infty.
@@ -1306,13 +1306,13 @@ Dans la suite \( E'\) est le dual topologique, c'est à dire l'espace des formes
                     \end{equation}
                     et donc
                     \begin{equation}
-                        \left( \int_{| g |<n}| g |^{q} \right)^{1-\frac{1}{ p }}\leq \| \ell \|, 
+                        \left( \int_{| g |<n}| g |^{q} \right)^{1-\frac{1}{ p }}\leq \| \ell \|,
                     \end{equation}
                     c'est à dire
                     \begin{equation}
                         \Big( \int_{| g |<n}| g |^q \Big)^{1/q}\leq \| \ell \|.
                     \end{equation}
-                    
+
                     Si ce n'était pas encore fait nous nous fixons un représentant de la classe \( g\) (qui est dans \( L^2\)), et nous nommons également \( g\) ce représentant. Nous posons alors
                     \begin{equation}
                         g_n=| g |^q\mtu_{| g |<n}
@@ -1358,7 +1358,7 @@ Dans la suite \( E'\) est le dual topologique, c'est à dire l'espace des formes
             \big| \frac{1}{ \mu(E) }gd\mu-a \big|=\big| \frac{1}{ \mu(E) }\int_E(g-a) \big|\leq  \frac{1}{ \mu(E) }\int_E| g-a |\leq\frac{1}{ \mu(E) }\mu(E)r=r.
         \end{align}
     \end{subequations}
-    Donc 
+    Donc
     \begin{equation}
         \frac{1}{ \mu(E) }\int_Egd\mu\in D,
     \end{equation}
@@ -1385,9 +1385,9 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \end{equation}
             En particulier pour tout ensemble mesurable \( A\) dans \( \Omega\), \( \int_A(g-g')d\mu=0\) parce que \( \mtu_A \in L^p(\Omega)\) parce que nous avons supposé que l'espace était fini. La proposition \ref{PropRERZooYcEchc} nous dit alors que \( g-g'=0\) dans \( L^q\).
 
-    La partie difficile est de montrer que \( \Phi\) est surjective. 
-            
-            
+    La partie difficile est de montrer que \( \Phi\) est surjective.
+
+
     Soit \( \phi\in L^p(\Omega)'\). Si \( \phi=0\), c'est bien dans l'image de \( \Phi\); nous supposons donc que non. Nous allons commencer par prouver qu'il existe une (classe de) fonction \( g\in L^1(\Omega)\) telle que \( \Phi_g(f)=\phi(f)\) pour tout \(f\in L^{\infty}(\Omega,\mu)\); nous montrerons ensuite que \( g\in L^q\) et que le tout est une isométrie.
 
     \begin{subproof}
@@ -1401,7 +1401,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \begin{equation}
                 \mu(E\setminus E_k)=\mu(E)-\mu(E_k),
             \end{equation}
-            et vu que \( E_k\to E\) est une suite croissante, le lemme \ref{LemAZGByEs}\ref{ItemJWUooRXNPci}, sachant que \( \mu\) est une mesure «normale», donne
+            et vu que \( E_k\to E\) est une suite croissante, le lemme \ref{LemAZGByEs}\ref{ItemJWUooRXNPci}, sachant que \( \mu\) est une mesure « normale », donne
             \begin{equation}
                 \lim_{n\to \infty} \mu(E_k)=\mu\big( \bigcup_kE_k \big).
             \end{equation}
@@ -1421,7 +1421,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
 
         \item[Mesure absolument continue]
 
-            En prime, si \( \mu(E)=0\) alors \( \nu(E)=0\) parce que 
+            En prime, si \( \mu(E)=0\) alors \( \nu(E)=0\) parce que
             \begin{equation}
                 \mu(E)=0\Rightarrow \| \mtu_E \|_p=0\Rightarrow \mtu_E=0\text{ (dans \( L^p\))}\Rightarrow\phi(\mtu_E)=0
             \end{equation}
@@ -1439,19 +1439,19 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             Nous avons donc exprimé \( \phi\) comme une intégrale pour les fonctions caractéristiques d'ensembles.
 
         \item[Pour les fonctions étagées]
-            
+
             Par linéarité si \( f\) est mesurable et étagée nous avons aussi
             \begin{equation}
                 \phi(f)=\int f\bar gd\mu=\Phi_g(f).
             \end{equation}
-            
+
         \item[Pour \( f\in L^{\infty}(\Omega)\)]
 
             Une fonction \( f\in L^{\infty}\) est une fonction presque partout bornée. Nous supposons que \( f\) est presque partout bornée par \( M\). Par ailleurs cette \( f\) est limite uniforme de fonctions étagées : \( \| f_k-f \|_{\infty}\to 0\) en posant \( f_k=f\mtu_{| f |\leq k}\). Pour chaque \( k \) nous avons l'égalité
             \begin{equation}    \label{EqPDCJooGNjuAO}
                 \Phi_g(f_k)=\phi(f_k).
             \end{equation}
-            Par ailleurs la fonction \( f_k\bar g\) est majorée par la fonction intégrable \( M\bar g\) et le théorème de la convergence dominée \ref{ThoConvDomLebVdhsTf} nous donne 
+            Par ailleurs la fonction \( f_k\bar g\) est majorée par la fonction intégrable \( M\bar g\) et le théorème de la convergence dominée \ref{ThoConvDomLebVdhsTf} nous donne
             \begin{equation}
                 \lim_{k\to \infty} \Phi_g(f_i)=\lim_{k\to \infty} \int f_k\bar g=\int f\bar g=\Phi_g(f).
             \end{equation}
@@ -1485,7 +1485,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \begin{equation}
                 \lim_{n\to \infty} \int f_ng^+=\int fg^+.
             \end{equation}
-            Faisant cela pour les trois autres parties de \( \bar g\) nous avons prouvé que si \( f\in L^p\) est réelle et positive, 
+            Faisant cela pour les trois autres parties de \( \bar g\) nous avons prouvé que si \( f\in L^p\) est réelle et positive,
             \begin{equation}
                 \int f\bar g=\phi(f),
             \end{equation}
@@ -1499,7 +1499,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
 
         \item[Isométrie : mise en place]
 
-            Nous devons prouver que cette bijection est isométrique. Soit \( \phi\in (L^p)'\) et \( g\in L^q\) telle que \( \Phi_g=\phi\). Il faut prouver que 
+            Nous devons prouver que cette bijection est isométrique. Soit \( \phi\in (L^p)'\) et \( g\in L^q\) telle que \( \Phi_g=\phi\). Il faut prouver que
             \begin{equation}
                 \| g \|_q=\| \phi \|_{(L^p)'}.
             \end{equation}
@@ -1523,7 +1523,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
 
         \item[Si \( p=1\)]
 
-            Si \( E\) est un ensemble mesurable, alors 
+            Si \( E\) est un ensemble mesurable, alors
             \begin{equation}
                 | \int_Egd\mu |=\big| \phi(\mtu_E) \big|.
             \end{equation}
@@ -1546,7 +1546,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             et donc que \( g\in L^{\infty}\).
 
             Notons que cet argument ne tient pas avec \( p\neq 1\) parce que l'équation \eqref{EqUPCTooJvoKKI} terminerait sur \( \| \phi \|\mu(E)^{1/p}\). Du coup l'ensemble \( S\) à prendre serait \( S=\{ t\in \eC\tq | t |\leq \| \phi \|\mu(E)^{1/p-1} \}\) et nous sommes en dehors des hypothèses du lemme parce qu'il n'y a pas d'ensemble \emph{indépendant} de \( E\) dans lequel l'intégrale \( \frac{1}{ \mu(E) }\int_{E}\bar gd\mu\) prend ses valeurs.
-            
+
         \item[\( 1<p<\infty\)]
 
             La fonction
@@ -1556,7 +1556,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
                     1    &    \text{si \( g(x)=0\)}
                 \end{cases}
             \end{equation}
-            a la propriété de faire \( \alpha g=| g |\) en même temps que \( | \alpha(x) |=1\) pour tout \( x\). Nous définissons 
+            a la propriété de faire \( \alpha g=| g |\) en même temps que \( | \alpha(x) |=1\) pour tout \( x\). Nous définissons
             \begin{equation}
                 E_n=\{ x\tq | g(x) |\leq n \}
             \end{equation}
@@ -1572,15 +1572,15 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \begin{equation}
                 \phi(f_n)=\Phi_g(f_n).
             \end{equation}
-            Par ailleurs, 
+            Par ailleurs,
             \begin{equation}
-                f_n\bar g=\mtu_{E_n}| g^{q-1} |\frac{ g }{ | g | }\bar g, 
+                f_n\bar g=\mtu_{E_n}| g^{q-1} |\frac{ g }{ | g | }\bar g,
             \end{equation}
             donc\quext{Dans \cite{MathAgreg}, cette équation arrive sans modules, ce qui me laisse entendre que \( \phi(f_n)\) est réel et positif pour pouvoir écrire que \( \phi(f_n)\leq \| \phi \|\| f_n \|_p\), mais je ne comprends pas pourquoi.}
             \begin{equation}
                 \left|\int_{E_n}| g |^qd\mu\right|=|\int_{\Omega}f_n\bar gd\mu|=|\phi(f_n)|\leq \| \phi \|\| f_n \|_p=\| \phi \|\left( \int_{E_n}| f_n |^p \right)^{1/p}=\| \phi \|\left( \int_{E_n}| g |^q \right)^{1/p}.
             \end{equation}
-            
+
             Nous avons de ce fait une inégalité de la forme \( A\leq \| \phi \|A^{1/p}\) et donc aussi \( A^{1/p}\leq \| \phi \|^{1/p}A^{1/p^2}\), et donc \( A\leq \| \phi \|\| \phi \|^{1/p}A^{1/p^2}\). Continuant ainsi à injecter l'inégalité dans elle-même,
             \begin{equation}
                 \left| \int_{E_n}| g |^qd\mu \right| \leq\| \phi \|^{1+\frac{1}{ p }+\ldots+\frac{1}{ p^k }}\left( \int_{E_n}| g |^qd\mu \right)^{1/p^k}.
@@ -1597,8 +1597,8 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \begin{equation}
                 \| g \|_q\leq \| \phi \|.
             \end{equation}
-            
-            Ceci achève de prouver que l'application \( \phi\mapsto \Phi_g\) est une isométrie, et donc le théorème. 
+
+            Ceci achève de prouver que l'application \( \phi\mapsto \Phi_g\) est une isométrie, et donc le théorème.
 
     \end{subproof}
 \end{proof}
@@ -1619,7 +1619,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
             \begin{equation}
                 \begin{aligned}
                     \Phi\colon L^q&\to (L^p)' \\
-                    u&\mapsto \Big( \Phi_u\colon f\to \int_{\Omega}fu\,d\mu \Big) 
+                    u&\mapsto \Big( \Phi_u\colon f\to \int_{\Omega}fu\,d\mu \Big)
                 \end{aligned}
             \end{equation}
             est une bijection isométrique.
@@ -1656,7 +1656,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
     \begin{equation}
         0=\Phi_f(\varphi_n)
     \end{equation}
-    En passant à la limite, nous voyons que \( \Phi_f\) est la forme nulle. Elle est donc égale à \( \Phi_0\). La partie «unicité» du théorème de représentation de Riesz \ref{ThoSCiPRpq} nous indique alors que \( f=0\) dans \( L^p\) et donc \( f=0\) presque partout.
+    En passant à la limite, nous voyons que \( \Phi_f\) est la forme nulle. Elle est donc égale à \( \Phi_0\). La partie « unicité » du théorème de représentation de Riesz \ref{ThoSCiPRpq} nous indique alors que \( f=0\) dans \( L^p\) et donc \( f=0\) presque partout.
 \end{proof}
 
 \begin{proposition} \label{PropLGoLtcS}
@@ -1679,7 +1679,7 @@ Note : ici nous considérons dans \( L^p\) des fonctions à valeurs complexes, e
     L'annulation de la dernière intégrale implique par la proposition \ref{PropUKLZZZh} que \( f-C=0\) dans \( L^2\), c'est à dire \( f=C\) presque partout.
 \end{proof}
 
-%--------------------------------------------------------------------------------------------------------------------------- 
+%---------------------------------------------------------------------------------------------------------------------------
 \subsection{Approximation de l'unité}
 %---------------------------------------------------------------------------------------------------------------------------
 
@@ -1722,7 +1722,7 @@ Le lemme suivant permet de construire des approximations de l'unité intéressan
             Soit \( \varphi\) une fonction continue et positive sur \( S^1\) telle que \( \varphi(x)<\varphi(0)\) pour tout \( x\notin 2\pi \eZ\). Dans ce cas la mesure à prendre pour l'intégrale est \( \frac{ dy }{ 2\pi }\).
         \item
             Soit \( \varphi\) est une fonction continue et positive à support compact sur \( \eR^d\) telle que \( \varphi(x)>\varphi(0)\) pour tout \( x\neq 0\).
-            
+
     \end{enumerate}
 \end{lemma}
 
@@ -1730,7 +1730,7 @@ Le lemme suivant permet de construire des approximations de l'unité intéressan
     Soit \( (\varphi_k)\) une approximation de l'unité sur \( \Omega=\eR^d\) ou \( (S^1)^d\).
     \begin{enumerate}
         \item
-            Si \( g\) est mesurable et bornée sur \( \Omega\) et si \( g\) est continue en \( x_0\) alors 
+            Si \( g\) est mesurable et bornée sur \( \Omega\) et si \( g\) est continue en \( x_0\) alors
             \begin{equation}
                 (\varphi_k*g)(x_0)\to g(x_0).
             \end{equation}
@@ -1753,7 +1753,7 @@ Le lemme suivant permet de construire des approximations de l'unité intéressan
         \item
             Nous notons \( d_k=(\varphi_k*g)(x_0)-g(x_0)\) et nous devons prouver que \( d_k\to 0\). Vu que \( \varphi_k\) est d'intégrale \( 1\) sur \( \Omega\) nous pouvons écrire
             \begin{equation}
-                |d_k|=\big| \int_{\Omega}\big( g(x_0-y)-g(x_0) \big)\varphi_k(y)dy\big|\leq\int_{\Omega}\big| g(x_0-y)-g(x_0) \big| |\varphi_k(y) |dy. 
+                |d_k|=\big| \int_{\Omega}\big( g(x_0-y)-g(x_0) \big)\varphi_k(y)dy\big|\leq\int_{\Omega}\big| g(x_0-y)-g(x_0) \big| |\varphi_k(y) |dy.
             \end{equation}
             Nous notons \( M=\sup_k\| \varphi_k \|_1\), et nous considérons \( \alpha>0\) tel que
             \begin{equation}
@@ -1767,7 +1767,7 @@ Le lemme suivant permet de construire des approximations de l'unité intéressan
 
         \item
 
-            Nous posons \( d_k(x)=(\varphi_k*g)(x)-g(x)\) et nous voulons prouver que \( \| d_k \|_{\infty}\to 0\), c'est à dire que \( d_k(x)\) converge vers zéro uniformément en \( x\). Nous posons aussi 
+            Nous posons \( d_k(x)=(\varphi_k*g)(x)-g(x)\) et nous voulons prouver que \( \| d_k \|_{\infty}\to 0\), c'est à dire que \( d_k(x)\) converge vers zéro uniformément en \( x\). Nous posons aussi
             \begin{equation}
                 \tau_y(g)\colon x\mapsto g(x-y).
             \end{equation}
@@ -1816,7 +1816,7 @@ Une petite remarque en passant : aussi triste que cela en ait l'air, la converge
 \begin{equation}
     f_n(x)=f(x)+\frac{1}{ n }
 \end{equation}
-converge uniformément vers \( f\), mais 
+converge uniformément vers \( f\), mais
 \begin{equation}
     \| f_n-f \|_p=\int_{\Omega}\frac{1}{ n }
 \end{equation}
@@ -1830,7 +1830,7 @@ Nous allons beaucoup travailler avec le \defe{système trigonométrique}{systèm
 \begin{equation}
     e_n(t)= e^{int}.
 \end{equation}
-Une bonne partie de la douleur qu'évoque mot «densité» consiste à montrer que ce système est total dans \( L^2(S^1)=L^2(\mathopen[ 0 , 2\pi \mathclose])\), et donc en est une base hilbertienne. Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonction de la forme \( P=\sum_{k=-N}^NP_ke_k\) pour des constantes \( P_k\).
+Une bonne partie de la douleur qu'évoque mot « densité » consiste à montrer que ce système est total dans \( L^2(S^1)=L^2(\mathopen[ 0 , 2\pi \mathclose])\), et donc en est une base hilbertienne. Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonction de la forme \( P=\sum_{k=-N}^NP_ke_k\) pour des constantes \( P_k\).
 
 Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonction de la forme
 \begin{equation}
@@ -1846,7 +1846,7 @@ Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonctio
         f*e_n=c_n(f)e_n.
     \end{equation}
 \item
-            
+
     Si \( P\) est un polynôme trigonométrique et si \( f\in L^1(S^1)\) alors \( f*P\) est encore un polynôme trigonométrique.
     \end{enumerate}
 \end{lemma}
@@ -1869,7 +1869,7 @@ Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonctio
 \end{proof}
 
 \begin{example} \label{ExDMnVSWF}
-    Sur \( S^1\) nous construisons alors l'approximation de l'unité basée sur la fonction \( 1+\cos(x)\) et le lemme \ref{LemCNjIYhv}. Cette fonction est évidemment un polynôme trigonométrique parce que 
+    Sur \( S^1\) nous construisons alors l'approximation de l'unité basée sur la fonction \( 1+\cos(x)\) et le lemme \ref{LemCNjIYhv}. Cette fonction est évidemment un polynôme trigonométrique parce que
     \begin{equation}
         \cos(x)=\frac{  e^{ix}+ e^{-ix} }{2}.
     \end{equation}
@@ -1898,9 +1898,9 @@ Un \defe{polynôme trigonométrique}{polynôme!trigonométrique} est une fonctio
 \begin{remark}
     Deux remarques.
     \begin{itemize}
-        \item 
+        \item
             Il n'est pas possible que les polynômes trigonométriques soient dense dans \( L^{\infty}\) parce qu'une limite uniforme de fonctions continues est continue (c'est le théorème \ref{ThoUnigCvCont}).
-        \item 
+        \item
             Nous donnerons au théorème \ref{ThoDPTwimI} une démonstration indépendante de la densité des polynômes trigonométriques dans \( L^p(S^1)\).
     \end{itemize}
 \end{remark}

--- a/83_analyse_fonctionnelle.tex
+++ b/83_analyse_fonctionnelle.tex
@@ -118,7 +118,7 @@
     \end{subequations}
 \end{definition}
 
-\begin{theorem}[Haha-Banach, première forme géométrique\cite{TQSWRiz}]  \label{ThoSAJjdZc}
+\begin{theorem}[Hahn-Banach, première forme géométrique\cite{TQSWRiz}]  \label{ThoSAJjdZc}
     Soit \( E\) un espace vectoriel topologique et \( A\), \( B\) deux convexes non vides disjoints de \( E\). Si \( A\) est ouvert, il existe un hyperplan fermé qui sépare \( A\) et \( B\) au sens large.
 \end{theorem}
 


### PR DESCRIPTION
- Exempe → Exemple (2)
- trailing spaces
- relecture complète :-)