### PR TITLE
(latex) Remplace frenchb par french

### DIFF
--- a/e_mazhe.tex
+++ b/e_mazhe.tex
@@ -77,7 +77,7 @@
 \usepackage{array}
 
 \usepackage[fr]{exocorr}
-\usepackage[english,frenchb]{babel}
+\usepackage[english,french]{babel}
 \usepackage{listingsutf8}   % Has to be called after babel
 
 

--- a/manuel_du_contributeur_fr/e_manuel.tex
+++ b/manuel_du_contributeur_fr/e_manuel.tex
@@ -49,7 +49,7 @@
 \usepackage{lmodern}
 \usepackage[a4paper,margin=2cm]{geometry} 
 \usepackage{hyperref}                      
-\usepackage[english,frenchb]{babel}
+\usepackage[english,french]{babel}
 
 \newcommand{\info}[1]{\texttt{#1}}
 \newcommand{\TikZ}{Ti{\it k}Z}

--- a/mazhe.tex
+++ b/mazhe.tex
@@ -77,7 +77,7 @@
 \addInputPath{tex/front_back_matter}
 
 % SCRIPT MARK -- GARDE MES NOTES
-\selectlanguage{frenchb}
+\selectlanguage{french}
 \input{gardeFrido}
 
 \notbool{isBook}{
@@ -95,7 +95,7 @@
 \input{gardeMazhe}
 
 % SCRIPT MARK -- GARDE ENSEIGNEMENT
-\selectlanguage{frenchb}
+\selectlanguage{french}
 \input{gardeEnseignement}
 
 % SCRIPT MARK -- TOC
@@ -120,12 +120,12 @@
 \input{AvertissementMazhe}
 
 % SCRIPT MARK -- MOODLE
-\selectlanguage{frenchb}
+\selectlanguage{french}
 \input{45_contreMoodle}
 
 % SCRIPT MARK -- FRIDO
 
-\selectlanguage{frenchb}
+\selectlanguage{french}
 
 \ifbool{isFrido}
 {
@@ -543,7 +543,7 @@
 \emptyInputPath
 \addInputPath{tex/matlab}
 
-    \selectlanguage{frenchb}
+    \selectlanguage{french}
 \part{Matlab}
 \input{133_matlab}
 

--- a/tex/front_back_matter/gardeVolume.tex
+++ b/tex/front_back_matter/gardeVolume.tex
@@ -20,7 +20,7 @@
 
 \pagestyle{empty}
 
-    \selectlanguage{frenchb}
+    \selectlanguage{french}
 
     \vphantom{Woo}
 


### PR DESCRIPTION
J'obtiens des erreurs de compilation avec Tex Live 2017 dues à l'utilisation de `\selectlanguage{frenchb}` qui n'est plus supportée depuis la version 3.0c (2014/04/18) de `babel-french`. Il faut utiliser l'argument `french`.

J'en ai profité pour remplacer l'option obsolète `frenchb` de `babel` par `french`. 
