### PR TITLE
(python) Corrige une régression dans lst_exemple.py

### DIFF
--- a/manuel_du_contributeur_fr/lst_exemple.py
+++ b/manuel_du_contributeur_fr/lst_exemple.py
@@ -11,14 +11,14 @@ import plugins_agreg
 myRequest = latexparser.PytexTools.Request("mesure")
 myRequest.ok_hash=commons.ok_hash
 
-myRequest.add_plugin(plugins_agreg.set_isAgreg,"before_pytex")
+myRequest.add_plugin(plugins_agreg.set_isFrido,"before_pytex")
 
 myRequest.original_filename="mazhe.tex"
 
 myRequest.ok_filenames_list=["e_mazhe"]
 myRequest.ok_filenames_list.extend(["gardeFrido"])
 myRequest.ok_filenames_list.extend(["43_mesure"])
-myRequest.ok_filenames_list.extend(["56_espace_vecto_norme"])
+myRequest.ok_filenames_list.extend(["181_espace_vecto_norme"])
 myRequest.ok_filenames_list.extend(["134_choses_finales"])
 
 


### PR DESCRIPTION
Lors du renommage de set_isAgreg en set_isFrido dans le plugin_agreg
   commit 649a3092d09fdd328ab01b2b1b398e759a6d8bcb
le fichier lst_exemple.py a été oublié.