### PR TITLE
(typo) Remanie les « Soit ... tel que ... »

### DIFF
--- a/tex/exercices/exoUnif.tex
+++ b/tex/exercices/exoUnif.tex
@@ -1283,7 +1283,7 @@ où $(\star,\star) = (t,g(t^2))$.
 
    Travaux perso 2 ---------------
 
-   1. Soit deux réels $x$ et $y$ vérifiant $0 < x < y$. On veut montrer
+   1. Soient deux réels $x$ et $y$ vérifiant $0 < x < y$. On veut montrer
    que pour tout naturel $k \geq 2$, on a
    \[0 < \sqrt[k]{y} - \sqrt[k]{x} < \sqrt[k]{y-x}.\]
 

--- a/tex/exocorr/corr0010.tex
+++ b/tex/exocorr/corr0010.tex
@@ -7,9 +7,9 @@
 
 \begin{enumerate}
 \item 
-\item Soit $M>1$, et $K,L$ tels que $k>K$ et $l>L$ impliquent $x_k>M$ et $y_k>M$. Dans ce cas, $m>\max\{K,L\}$ implique $(xy)_m>M^2>M$.
-\item Soit $M>0$, $K$ tel que $k>K$ implique $x_k>M+1$ et $L$ tel que $l>L$ implique $| z_l-a |<\frac{ 1 }{2}$. Alors $m>\max\{ K,L \}$ implique $(x+z)_k>M+1\pm\frac{ 1 }{2}>M+\frac{ 1 }{2}>M$.
-\item Soit $M>0$ et $K$ tel que $k>K$ implique $x_k>\frac{ M }{ a }+1$, et $z_k>a-\epsilon$. Un tel $k$ peut être trouvé pour tout choix de $\epsilon$. Nous choisissons $\epsilon$ de façon à avoir $a-\epsilon>0$, et nous minorons
+\item Soientt $M>1$ et $K,L$ tels que $k>K$ et $l>L$ impliquent $x_k>M$ et $y_k>M$. Dans ce cas, $m>\max\{K,L\}$ implique $(xy)_m>M^2>M$.
+\item Soient $M>0$, $K$ tel que $k>K$ implique $x_k>M+1$ et $L$ tel que $l>L$ implique $| z_l-a |<\frac{ 1 }{2}$. Alors $m>\max\{ K,L \}$ implique $(x+z)_k>M+1\pm\frac{ 1 }{2}>M+\frac{ 1 }{2}>M$.
+\item Soient $M>0$ et $K$ tels que $k>K$ implique $x_k>\frac{ M }{ a }+1$, et $z_k>a-\epsilon$. Un tel $k$ peut être trouvé pour tout choix de $\epsilon$. Nous choisissons $\epsilon$ de façon à avoir $a-\epsilon>0$, et nous minorons
 \begin{equation}
 	x_kz_k>\left( \frac{ M }{ a }+1 \right)(a-\epsilon)=M+a-\frac{ \epsilon M }{ a }-\epsilon.
 \end{equation}

--- a/tex/exocorr/corr0013.tex
+++ b/tex/exocorr/corr0013.tex
@@ -11,7 +11,7 @@
 \item Oui : la suite $1,2,1,2,1,2,\ldots$
 \item idem.
 \item La suite $-1,0,1,-2,-1,0,1,2,-3,-2,-1,0,1,2,3,\ldots$ qui consiste à énumérer de $-n$ à $n$ puis de $-(n+1)$ à $n+1$ et ainsi de suite.
-\item Soient $a>b$, deux valeurs atteintes une infinité de fois par la suite. Soit $r\in\eR$, et prouvons que la suite ne peut pas converger vers $r$. Disons que $r\neq a$, dans ce cas, si $| r-a |=\sigma$, pour tout $K>0$, il existe un $k>K$ tel que $x_k=a$ et donc tel que $| x_k-r |\leq\epsilon$ pour $\epsilon=\sigma/2$ par exemple. Même raisonnement si $r\neq b$.
+\item Soient $a>b$, deux valeurs atteintes une infinité de fois par la suite. Soit $r\in\eR$. Prouvons que la suite ne peut pas converger vers $r$. Disons que $r\neq a$, dans ce cas, si $| r-a |=\sigma$, pour tout $K>0$, il existe un $k>K$ tel que $x_k=a$ et donc tel que $| x_k-r |\leq\epsilon$ pour $\epsilon=\sigma/2$ par exemple. Même raisonnement si $r\neq b$.
 
 Donc une suite périodique qui converge ne peut pas prendre deux valeurs distinctes (ici : $a$ et $b$). Nous en déduisons qu'elle doit être constante.
 

--- a/tex/exocorr/corr0015.tex
+++ b/tex/exocorr/corr0015.tex
@@ -1,5 +1,5 @@
 % This is part of Exercices et corrigés de CdI-1
-% Copyright (c) 2011,2017
+% Copyright (c) 2011
 %   Laurent Claessens
 % See the file fdl-1.3.txt for copying conditions.
 
@@ -8,7 +8,7 @@
 Étant donné qu'il n'y a qu'une quantité dénombrable de rationnels, une simple adaptation de la question \ref{ItemEnumiE13} de l'exercice \ref{exo0013} donne une suite qui contient une infinité de fois chaque rationnel. Toute suite de rationnels est une sous-suite de cette suite, et en particulier si $r$ est un réel quelconque, une suite de rationnels qui converge vers $r$ est une sous-suite de la suite considérée.
 
 \begin{alternative}
-En réalité, toute suite qui énumère tous les rationnels convient. Il ne faut pas spécialement que tous les rationnels arrivent chacun une infinité de fois. En effet, soit $r\in\eR$, et $B=B(r,\epsilon)$, une boule de rayon $\epsilon$ autour de $r$. Si $x_k$ est une suite qui énumère tous les rationnels, pour tout $N$, il existe une infinité de $x_n\in B$ ($b>N$), parce que cette boule contient une infinité de rationnels, qui ne peuvent donc pas être tous énumérés avant le $N$ième élément de la suite $x_k$.
+En réalité, toute suite qui énumère tous les rationnels convient. Il ne faut pas spécialement que tous les rationnels arrivent chacun une infinité de fois. En effet, soient $r\in\eR$, et $B=B(r,\epsilon)$, une boule de rayon $\epsilon$ autour de $r$. Si $x_k$ est une suite qui énumère tous les rationnels, pour tout $N$, il existe une infinité de $x_n\in B$ ($b>N$), parce que cette boule contient une infinité de rationnels, qui ne peuvent donc pas être tous énumérés avant le $N$ième élément de la suite $x_k$.
 \end{alternative}
 
 \end{corrige}

--- a/tex/exocorr/corrJanvier010.tex
+++ b/tex/exocorr/corrJanvier010.tex
@@ -4,7 +4,7 @@
 % See the file fdl-1.3.txt for copying conditions.
 \begin{corrige}{Janvier010}
 
-Soit $f : [a,b] \to \eR$ une fonction continue, et dérivable sur $\mathopen]a,b\mathclose[$.  Alors il existe $c \in \mathopen]a,b\mathclose[$ tel que
+Soit $f : [a,b] \to \eR$ une fonction continue et dérivable sur $\mathopen]a,b\mathclose[$.  Alors il existe $c \in \mathopen]a,b\mathclose[$ tel que
 \begin{equation}
   f^\prime(c) = \frac{f(b)-f(a)}{b-a}.
 \end{equation}

--- a/tex/exocorr/corrTP20090001.tex
+++ b/tex/exocorr/corrTP20090001.tex
@@ -17,7 +17,7 @@
 			La propriété est donc prouvée dans le cas où $A$ est un intervalle ouvert. Si l'ensemble $A$ est un intervalle de la forme $\mathopen[ a , b \mathclose]$, alors on peut utiliser la continuité pour prouver que si $f$ est continues en $a$ et $b$ et constante sur $\mathopen] a , b \mathclose[$, alors elle est constante sur $\mathopen[ a , b \mathclose]$. Pour s'en convaincre, supposons que $f(x)=y_0$ sur $\mathopen] a , b \mathclose[$ et que $f(a)=y_1$. Dans ce cas, étant donné que $f$ est continue en $a$, il existe un voisinage de $a$ dans lequel $f$ prend ses valeurs uniquement dans $B(y_1,\epsilon)$. Si nous choisissons $\epsilon$ de telle manière à exclure $y_0$ de la boule (ce qui est possible si $y_1\neq y_0$), alors nous contredisons la continuité de $f$ en $a$ parce que tout voisinage de $a$ contient un point de $\mathopen] a , b \mathclose[$ où $f$ vaut $y_0$.
 
 		\item
-			Considérons $a_0$, un point par rapport auquel $\Omega$ est étoilé. Soit $a\in\Omega$, et considérons le segment de droite $\gamma\colon [0,1]1\to \Omega$ tel que $\gamma(0)=a_0$ et $\gamma(1)=a$. Nous considérons maintenant la fonction
+			Considérons $a_0$, un point par rapport auquel $\Omega$ est étoilé. Soit $a\in\Omega$. Considérons le segment de droite $\gamma\colon [0,1]1\to \Omega$ tel que $\gamma(0)=a_0$ et $\gamma(1)=a$. Nous considérons maintenant la fonction
 			\begin{equation}
 				\begin{aligned}
 					g\colon [0,1]&\to \eR \\

--- a/tex/exocorr/corrVariete0013.tex
+++ b/tex/exocorr/corrVariete0013.tex
@@ -8,7 +8,7 @@
 
 
 \begin{enumerate}
-\item Soit $C$ le cube, et $B$ le cube plein dont $C$ est le bord. Par
+\item Soient $C$ le cube et $B$ le cube plein dont $C$ est le bord. Par
   le théorème de la divergence,
   \begin{equation*}
     \iint_C G\cdot d S = \iiint_B \nabla\cdot G

--- a/tex/exocorr/corr_I-1-11.tex
+++ b/tex/exocorr/corr_I-1-11.tex
@@ -41,7 +41,7 @@ où la limite est une limite à droite : la limite à gauche n'existe pas.
 \end{lemma}
 
 \begin{proof}
-Soit $M>0$, et prouvons que $\exists\epsilon$ tel que $\zeta(1+\epsilon)\geq M$. D'abord, choisissons un $k$ tel que 
+Soit $M>0$. Prouvons que $\exists\epsilon$ tel que $\zeta(1+\epsilon)\geq M$. D'abord, choisissons un $k$ tel que 
 \begin{equation}
 	\sum_{n=1}^k\frac{1}{ n }>M,
 \end{equation}

--- a/tex/exocorr/corrreserve0002.tex
+++ b/tex/exocorr/corrreserve0002.tex
@@ -23,7 +23,7 @@
 	\begin{equation}
 		\lim_{(x,y)\to(t,t)}\xi(x,y)=t.
 	\end{equation}
-	En effet, soit $\epsilon<0$ et $\delta$ tel que pour tout $(x,y)\in B\big( (t,t),\delta \big)$, nous ayons $| x-y |<\epsilon$. Nous avons alors
+	En effet, soient $\epsilon<0$ et $\delta$ tels que pour tout $(x,y)\in B\big( (t,t),\delta \big)$, nous ayons $| x-y |<\epsilon$. Nous avons alors
 	\begin{equation}
 		\big| \xi(x,y)-x \big|<| y-x |<\epsilon.
 	\end{equation}

--- a/tex/exocorr/exo0084.tex
+++ b/tex/exocorr/exo0084.tex
@@ -5,7 +5,7 @@
 
 \begin{exercice}\label{exo0084}
 
-Soit $f \colon (X,d_X) \to (Y,d_Y)$ et $g \colon (Y,d_Y) \to (Z,d_Z)$ des applications continues entre espaces métriques.  Montrer que la composition $g \circ f \colon (X,d_X) \to (Z,d_Z)$ est continue.
+Soient $f \colon (X,d_X) \to (Y,d_Y)$ et $g \colon (Y,d_Y) \to (Z,d_Z)$ des applications continues entre espaces métriques.  Montrer que la composition $g \circ f \colon (X,d_X) \to (Z,d_Z)$ est continue.
 
 \corrref{0084}
 \end{exercice}

--- a/tex/exocorr/exoExamDec2011-0002.tex
+++ b/tex/exocorr/exoExamDec2011-0002.tex
@@ -6,7 +6,7 @@
 
 \begin{exercice}\label{exoExamDec2011-0002}
 
-    Soit \( f\colon \eR\to \eR\), une fonction continue et \( a\in \eR\) tel que \( f(a)>0\).
+    Soient \( f\colon \eR\to \eR\) une fonction continue et \( a\in \eR\) tels que \( f(a)>0\).
     \begin{enumerate}
         \item
             Montrer que l'ensemble \( \{ x\in\eR\tq f(x)>0 \}\) est ouvert.

--- a/tex/exocorr/exoJanvier003.tex
+++ b/tex/exocorr/exoJanvier003.tex
@@ -4,7 +4,7 @@
 % See the file fdl-1.3.txt for copying conditions.
 \begin{exercice}\label{exoJanvier003}
 
-Soit $n\in\eN_0$ et soient $a_0$, $a_1$,\ldots, $a_n\in\eR$ ($a_n\neq 0$). Vérifier que si $z\in\eC$ est solution de l'équation $a_nx^n+a_{n-1}x^{n-1}+\cdots+a_1x+a_0=0$, alors $\bar z$ l'est également.
+Soient $n\in\eN_0$ et $a_0$, $a_1$,\ldots, $a_n\in\eR$ ($a_n\neq 0$). Vérifier que si $z\in\eC$ est solution de l'équation $a_nx^n+a_{n-1}x^{n-1}+\cdots+a_1x+a_0=0$, alors $\bar z$ l'est également.
 
 \corrref{Janvier003}
 \end{exercice}

--- a/tex/frido/135_mesure.tex
+++ b/tex/frido/135_mesure.tex
@@ -1112,7 +1112,7 @@ Il n'y a en général pas égalité, mais nous allons immédiatement voir que da
 
             Nous avons \( \Omega_1\times \Omega_2\in S\) parce que c'est un rectangle.
 
-        \item[Tribu : complémentaire] Soit \( A\in S\) et montrons que \( A^c\in S\). Nous avons d'abord
+        \item[Tribu : complémentaire] Soit \( A\in S\). Montrons que \( A^c\in S\). Nous avons d'abord
             \begin{equation}
                 (A^c)_1(y)=\{ x\in \Omega_1\tq (x,y)\in A^c \}.
             \end{equation}

--- a/tex/frido/138_EspacesVectos.tex
+++ b/tex/frido/138_EspacesVectos.tex
@@ -268,7 +268,7 @@ Note au passage comme toujours : il y a un abus systématique de notation entre 
 \end{remark}
 
 \begin{proposition}
-    Soit \( f\in\aL(E,F)\) et \( g\in\aL(F,E)\). Alors il existe \( h\colon G\to E\) tel que \( f\circ h=g\) si et seulement s'il existe \( \tilde g\colon G_{\eL}\to E_{\eL}\) tel que \( f_{\eL}\circ \tilde g=g_{\eL}\).
+    Soient \( f\in\aL(E,F)\) et \( g\in\aL(F,E)\). Alors il existe \( h\colon G\to E\) tel que \( f\circ h=g\) si et seulement s'il existe \( \tilde g\colon G_{\eL}\to E_{\eL}\) tel que \( f_{\eL}\circ \tilde g=g_{\eL}\).
 \end{proposition}
 
 \begin{proof}
@@ -940,7 +940,7 @@ Nous considérons encore un espace vectoriel \( E\) de dimension finie \( n\) et
             Mais par hypothèse et par choix de \( a\) nous avons \( \mu_a=\mu=\chi\), donc en fait \( E_a=\eK[X]/(\chi)\). Mais nous savons que \( \deg(\chi)=\dim(E)\) et que \( \dim\big( \eK[X]/P \big)=\deg(P)\) par la proposition \ref{PropooCFZDooROVlaA}. Au final nous avons \( \dim(E_a)=\deg(\chi)=\dim(E)\). Et par conséquent \( E_a=E\). Cela prouver que \( a\) est un vecteur cyclique pour \( f\).
 
         \item[\ref{ITEMooLRXIooLWaYqJi} implique \ref{ITEMooLRXIooLWaYqJiii}]
-            Soit \( g\in \comC(f)\); nous devons prouver que \( g\) est un polynôme de \( f\). Par hypothèse nous avons un vecteur cyclique que nous notons \( v\). Nous avons un polynôme \( P\) (dépendant de \( g\)) tel que \( g(v)=P(f)v\). Nous allons voir que \( g=P(f)\). Soit \( y\in E\) et un polynôme \( Q\) tel que \( y=Q(f)v\); en notant que \( g\) commute avec \( P(f)\) nous avons 
+            Soit \( g\in \comC(f)\); nous devons prouver que \( g\) est un polynôme de \( f\). Par hypothèse nous avons un vecteur cyclique que nous notons \( v\). Nous avons un polynôme \( P\) (dépendant de \( g\)) tel que \( g(v)=P(f)v\). Nous allons voir que \( g=P(f)\). Soient \( y\in E\) et \( Q\) un polynôme tels que \( y=Q(f)v\); en notant que \( g\) commute avec \( P(f)\) nous avons 
             \begin{equation}
                 g(y)=g\big( Q(f)v \big)=Q(f)\big( g(v) \big)=Q(f)\big( P(f)v \big)=P(f)Q(f)v=P(f)y.
             \end{equation}

--- a/tex/frido/140_EspacesAffines.tex
+++ b/tex/frido/140_EspacesAffines.tex
@@ -253,7 +253,7 @@ Si le déterminant du système est nul, il y a soit pas de centre de symétrie, 
 Ce lemme est important car il permet de démonter qu'une application est affine en prouvant la linéarité des \( u_M\) séparément sans devoir prouver qu'elles sont égales.
 
 \begin{lemma}[\cite{MonCerveau}]       \label{LEMooXXTPooKYFGGM}
-    Soit \( M\in \affE\) et deux points \( A,B\in \affE\) donnés par \( A=M+x_a\), \( B=M+x_b\). Soit encore une application affine \( f\) sur \( \affE\). Alors
+    Soient \( M\in \affE\) et \( A,B\in \affE\) deux points donnés par \( A=M+x_a\), \( B=M+x_b\). Soit encore une application affine \( f\) sur \( \affE\). Alors
     \begin{equation}
         \vect{ AB }=u_f(x_b-x_a).
     \end{equation}
@@ -374,7 +374,7 @@ Si \( \affF\) et \( \affG\) sont des sous-espaces affines de \( \affE\) de direc
 \end{proposition}
 
 \begin{proof}
-    Soit \( F\) la direction de \( \affF\) et \( A\in\affF\). Nous considérons une base \( \{ e_i \}\) adaptée à \( F\) au sens \( \{ e_1,\ldots, e_k \}\) est une base de \( F\). Nous considérons maintenant le repère cartésien \( (A,\{ e_i \})\) avec \( A\in\affF\) et nous construisons l'application affine
+    Soient \( F\) la direction de \( \affF\) et \( A\in\affF\). Nous considérons une base \( \{ e_i \}\) adaptée à \( F\) au sens \( \{ e_1,\ldots, e_k \}\) est une base de \( F\). Nous considérons maintenant le repère cartésien \( (A,\{ e_i \})\) avec \( A\in\affF\) et nous construisons l'application affine
     \begin{equation}
         \begin{aligned}
             f\colon \affE&\to \eK^{n-k} \\

--- a/tex/frido/146_relativite.tex
+++ b/tex/frido/146_relativite.tex
@@ -20,7 +20,7 @@ C'est à dire que la distance $x'$ qu'aura parcouru l'athlète par rapport à mo
 \subsection{Bob et Alice}
 %------------------------
 
-Formalisons le concept de changement de repères. Pour cela, prenons deux amoureux, Bob et Alice\footnote{C'est plus poétique que dire \og soit $A$ et $B$, deux observateurs\fg{}.}. Mettons que Bob reste assis sur un banc pendant qu'Alice cours en ligne droite à une vitesse $v$. Tout deux déclenchent leur chronomètre quand Alice passe devant Bob. À tout moment, Bob et Alice ont leur repères de temps et d'espace. Par exemple si après un temps $t$, Alice voir une peau de banane à $1$ mètre devant elle, elle va dire \og Il y a une peau de banane à un mètre .\fg{}, tandis que Bob va dire \og Il y a une peau de banane à $(1+vt)$ mètres\fg.
+Formalisons le concept de changement de repères. Pour cela, prenons deux amoureux, Bob et Alice\footnote{C'est plus poétique que dire \og soient $A$ et $B$ deux observateurs\fg{}.}. Mettons que Bob reste assis sur un banc pendant qu'Alice cours en ligne droite à une vitesse $v$. Tout deux déclenchent leur chronomètre quand Alice passe devant Bob. À tout moment, Bob et Alice ont leur repères de temps et d'espace. Par exemple si après un temps $t$, Alice voir une peau de banane à $1$ mètre devant elle, elle va dire \og Il y a une peau de banane à un mètre .\fg{}, tandis que Bob va dire \og Il y a une peau de banane à $(1+vt)$ mètres\fg.
 
 Plus généralement, s'il se passe quelque chose à la position $x$ au temps $t$ pour Bob, ce quelque chose se passera au temps $t'=t$ à l'endroit $x'=x-vt$ pour Alice parce qu'en un temps $t$, elle aura déjà avancé d'une distance $vt$.
 
@@ -486,7 +486,7 @@ Il faut démontrer que sinus hyperbolique est injective et surjective. Calculons
 \begin{align}
 \lim_{x\to-\infty}\sinh(x)&=-\infty	&\lim_{x\to\infty}\sinh(x)=\infty.
 \end{align}
-Par ailleurs, la fonction sinus hyperbolique est continue et respecte donc le théorème de la valeur intermédiaire\footnote{Je t'avais dit que tout tons cours de math allait y passer hein.} \ref{ThoValInter}. Soit $y\in\eR$ et voyons s'il existe un $x\in\eR$ tel que $\sinh(x)=y$. Les deux limites indiquent qu'il existe $x_1\in\eR$ tel que $\sinh(x_1)<y$ et $x_2\in\eR$ tel que $\sinh(x_2)>y$. Le théorème de la valeur intermédiaire conclu qu'il existe un $x$ entre $x_1$ et $x_2$ tel que $\sinh(x)=y$. Cela prouve la surjectivité.
+Par ailleurs, la fonction sinus hyperbolique est continue et respecte donc le théorème de la valeur intermédiaire\footnote{Je t'avais dit que tout tons cours de math allait y passer hein.} \ref{ThoValInter}. Soit $y\in\eR$. Voyons s'il existe un $x\in\eR$ tel que $\sinh(x)=y$. Les deux limites indiquent qu'il existe $x_1\in\eR$ tel que $\sinh(x_1)<y$ et $x_2\in\eR$ tel que $\sinh(x_2)>y$. Le théorème de la valeur intermédiaire conclu qu'il existe un $x$ entre $x_1$ et $x_2$ tel que $\sinh(x)=y$. Cela prouve la surjectivité.
 
 Pour l'injectivité, on va utiliser le \href{http://fr.wikipedia.org/wiki/Théorème_de_Rolle}{théorème de Rolle} et une petite preuve par l'absurde. Supposons que $\sinh(x_1)=\sinh(x_2)$ avec $x_1\neq x_2$. Dans ce cas, le théorème de Rolle nous dit qu'il existe un $x$ entre $x_1$ et $x_2$ tel que $\sinh'(x)=0$. La dérivée de sinus hyperbolique étant cosinus hyperbolique, il faut se demander il existe un $x$ tel que $\cosh(x)=0$. Étant donné que $ e^{x}>0$ pour tout $x$, en fait le cosinus hyperbolique ne s'annule jamais.
 \end{proof}

--- a/tex/frido/158_Sobolev.tex
+++ b/tex/frido/158_Sobolev.tex
@@ -75,7 +75,7 @@ Nous introduisons l'espace \( L^1_{loc}(I)\)\nomenclature[Y]{\( L^1_{loc}(I)\)}{
 Nous verrons dans le corollaire \ref{CorCEPJGAu} que ce représentant pourra être prolongé par continuité sur \( \bar I\).
 
 \begin{proof}
-    Soit \( y_0\in I\) et \( u\in H^1(I)\). Nous considérons la fonction
+    Soient \( y_0\in I\) et \( u\in H^1(I)\). Nous considérons la fonction
     \begin{equation}
         \bar u(x)=\int_{y_0}^xu'(t)dt.
     \end{equation}
@@ -898,7 +898,7 @@ Note : ici \( \partial\) est l'opération de dérivée faible.
 \end{proof}
 
 \begin{theorem}[Théorème de plongement de Sobolev \cite{ooFZERooPVhoge}]
-    Soit \( k\in \eN\) et \( m>\frac{ d }{ 2 }+k\). Alors
+    Soient \( k\in \eN\) et \( m>\frac{ d }{ 2 }+k\). Alors
     \begin{equation}        \label{EQooIJZOooZiYSnJ}
         H^s(\eR^d)\subset C_0^k(\eR^d).
     \end{equation}

--- a/tex/frido/168_questionsFrido.tex
+++ b/tex/frido/168_questionsFrido.tex
@@ -342,7 +342,7 @@ alors nous définissons \( \pr(f)\) par
 \item La proposition \ref{PropNIBooSbXIKO}
 
 \begin{proposition}
-    Soit \( f\colon \eR\to \eR \) une fonction convexe et \( a\in \eR\). Il existe une constante \( c_a\in \eR\) telle que pour tout \( x\) nous ayons
+    Soient \( f\colon \eR\to \eR \) une fonction convexe et \( a\in \eR\). Il existe une constante \( c_a\in \eR\) telle que pour tout \( x\) nous ayons
     \begin{equation}
         f(x)-f(a)\geq c_a(x-a).
     \end{equation}

--- a/tex/frido/170_EspacesProjectifs.tex
+++ b/tex/frido/170_EspacesProjectifs.tex
@@ -238,7 +238,7 @@ nous entendons implicitement que \( f(\infty)=\infty\).
 L'inversion d'un cercle de \( \eR^2\) est définie par la proposition \ref{PROPDEFooVLIWooQgpLQa}. De nombreuses propriétés y sont décrites, y compris son écriture complexe dans la proposition \ref{PROPooEWXNooNshvHq}. Tout cela était du temps de \( \eR^2\) ou de \( \eC\), mais maintenant nous sommes dans \( \hat \eC\) et nous voulons plus.
 
 \begin{definition}[\cite{ooWNHWooGUnivi}]       \label{DEFooIUTZooWRaXts}
-    Soit \( \omega\in \eC\) et \( R\in \eR^*\). L'\defe{inversion}{inversion dans $\eC\cup\{ \infty \}$} de centre \( \omega\) et de \defe{puissance}{puissance!d'une inversion} \( R^2\) est l'application 
+    Soient \( \omega\in \eC\) et \( R\in \eR^*\). L'\defe{inversion}{inversion dans $\eC\cup\{ \infty \}$} de centre \( \omega\) et de \defe{puissance}{puissance!d'une inversion} \( R^2\) est l'application 
     \begin{equation}
         \begin{aligned}
             i\colon \hat \eC&\to \hat \eC \\

--- a/tex/frido/173_analyseR.tex
+++ b/tex/frido/173_analyseR.tex
@@ -549,7 +549,7 @@ Le lien avec le gradient est la définition du produit scalaire \eqref{DefYNWUFc
 
 
 \begin{proposition} \label{PropExistDiffUn}
-    Soit $f$ une fonction de $x$ et $y$ et un point $(a,b)\in\eR^2$. Si les nombres $\partial_xf(a,b)$ et $\partial_yf(a,b)$ existent et s'il existe une fonction $\alpha\colon \eR\to \eR$ telle que
+    Soient $f$ une fonction de $x$ et $y$ et un point $(a,b)\in\eR^2$. Si les nombres $\partial_xf(a,b)$ et $\partial_yf(a,b)$ existent et s'il existe une fonction $\alpha\colon \eR\to \eR$ telle que
     \begin{equation}        \label{eqCritDifffabsrt}
         \begin{aligned}[]
             f(x,y)=f(a,b)&+\frac{ \partial f }{ \partial x }(a,b)(x-a)+\frac{ \partial f }{ \partial y }(a,b)(y-b)\\

--- a/tex/frido/175_trigono.tex
+++ b/tex/frido/175_trigono.tex
@@ -24,7 +24,7 @@ Il ne faudrait pas déduire trop vite que la formule \( \| x \|^2=q(x)\) donne u
 \end{definition}
 
 \begin{lemma}   \label{LemewGJmM}
-    Soit \( q\) une forme quadratique et \( b\) la forme bilinéaire associée par le lemme \ref{LEMooLKNTooSfLSHt}.  Pour une application bijective \( f\colon E\to E\) telle que \( f(0)=0\), les conditions suivantes sont équivalentes: 
+    Soient \( q\) une forme quadratique et \( b\) la forme bilinéaire associée par le lemme \ref{LEMooLKNTooSfLSHt}.  Pour une application bijective \( f\colon E\to E\) telle que \( f(0)=0\), les conditions suivantes sont équivalentes: 
     \begin{enumerate}
         \item
             \( b\big( f(x),f(y) \big)=b(x,y)\) pour tout \( x,y\in E\);
@@ -226,7 +226,7 @@ Si vous ne voulez pas savoir ce qu'est un produit semi-direct de groupes, vous p
 \end{remark}
 
 \begin{proposition}[\cite{ooZYLAooXwWjLa}]      \label{PROPooDHYWooXxEXvl}
-    Soit \( n\geq 1\) et un élément \( R\) de \( \gO(n)\) de déterminant \( -1\) tel que \( R^2=\id\). En posant \( C_2=\{ \id,R \}\) nous avons
+    Soient \( n\geq 1\) et \( R\) un élément de \( \gO(n)\) de déterminant \( -1\) tels que \( R^2=\id\). En posant \( C_2=\{ \id,R \}\) nous avons
     \begin{equation}
         \gO(n)=\SO(n)\times_{\rho} C_2
     \end{equation}
@@ -315,7 +315,7 @@ Si vous ne voulez pas savoir ce qu'est un produit semi-direct de groupes, vous p
             \end{equation}
             Donc \( f(y)\) est à égale distance de \( x\) que \( y\). Autrement dit, \( f(y)\) est soit \( y\) soit \( \sigma_x(y)\). Mais comme \( x\) est unique point fixe, \( f(y)=\sigma_x(y)\). Ce raisonnement étant valable pour tout \( y\neq x  \) nous avons \( f=\sigma_x\).
         \item[\( f\) n'a pas de points fixes]
-            Soit \( x\in \eR\) et \( y=\frac{ x+f(x) }{ 2 }\). Nous posons \( g=\sigma_y\circ f\). Alors \( x\) est un point fixe de \( g\) parce que
+            Soient \( x\in \eR\) et \( y=\frac{ x+f(x) }{ 2 }\). Nous posons \( g=\sigma_y\circ f\). Alors \( x\) est un point fixe de \( g\) parce que
             \begin{equation}
                 g(x)=\sigma_y\big( f(x) \big)=2y-f(x)=x.
             \end{equation}
@@ -363,7 +363,7 @@ Si vous ne voulez pas savoir ce qu'est un produit semi-direct de groupes, vous p
 Le \defe{tétraèdre}{tétraèdre} est une pyramide à base triangulaire dont toutes les faces sont des triangles équilatéraux.
 
 \begin{proposition}[Isométries affines du tétraèdre régulier]       \label{PROPooVNLKooOjQzCj}
-    Soit un tétraèdre régulier \( T\) et son groupe d'isométries affines \( \Iso(T)\) (définition \ref{DEFooZGKBooGgjkgs}). Alors
+    Soient \( T\) un tétraèdre régulier et \( \Iso(T)\) son groupe d'isométries affines (définition \ref{DEFooZGKBooGgjkgs}). Alors
     \begin{equation}
         \Iso(T)\simeq S_4
     \end{equation}

--- a/tex/frido/185_topologie.tex
+++ b/tex/frido/185_topologie.tex
@@ -69,7 +69,7 @@ La proposition \ref{PropQZRNpMn} donnera des détails sur ce qu'il se passe lors
 \begin{proof}
     \begin{subproof}
     \item[Sens direct]
-        Nous supposons que \( f\) est une fonction continue. Soit \( a\in X\) et \( V\), un voisinage de \( f(a)\). Nous considérons \( \mO\), un voisinage ouvert de \( f(a)\) contenu dans \( V\); l'ensemble \( f^{-1}(\mO)\) est alors un ouvert contenant \( a\), et l'image de \( f^{-1}(\mO)\) par \( f\) est bien entendu contenue dans \( V\).
+        Nous supposons que \( f\) est une fonction continue. Soient \( a\in X\) et \( V\) un voisinage de \( f(a)\). Nous considérons \( \mO\), un voisinage ouvert de \( f(a)\) contenu dans \( V\); l'ensemble \( f^{-1}(\mO)\) est alors un ouvert contenant \( a\), et l'image de \( f^{-1}(\mO)\) par \( f\) est bien entendu contenue dans \( V\).
 
     \item[Sens inverse]
 
@@ -104,7 +104,7 @@ Quelques liens vers la notion de compacité.
 \end{definition}
 
 \begin{proposition}\label{PropXKUMiCj}
-    Soit \( X\) un espace topologique et \( K\subset X\). Les propriétés suivantes sont équivalentes :
+    Soient \( X\) un espace topologique et \( K\subset X\). Les propriétés suivantes sont équivalentes :
     \begin{enumerate}
         \item\label{ItemXYmGHFai}
             \( K\) est compact.
@@ -138,7 +138,7 @@ Quelques liens vers la notion de compacité.
 \index{compact!implique fermé}
 
 \begin{proof}
-    Soit \( X\) un espace séparé et \( K\) compact dans \( X\). Nous considérons \( x\in\complement K\) et, par hypothèse de séparation, pour chaque \( x\in K\) nous considérons un voisinage ouvert \( V_x\) de \( x\) et un voisinage ouvert \( W_x\) de \( y\) tels que \( V_x\cap W_x=\emptyset\). Bien entendu les \( V_x\) forment un recouvrement ouvert de \( K\) dont nous pouvons extraire un sous-recouvrement fini : soit \( S\) fini dans \( K\) tel que
+    Soient \( X\) un espace séparé et \( K\) compact dans \( X\). Nous considérons \( x\in\complement K\) et, par hypothèse de séparation, pour chaque \( x\in K\) nous considérons un voisinage ouvert \( V_x\) de \( x\) et un voisinage ouvert \( W_x\) de \( y\) tels que \( V_x\cap W_x=\emptyset\). Bien entendu les \( V_x\) forment un recouvrement ouvert de \( K\) dont nous pouvons extraire un sous-recouvrement fini : soit \( S\) fini dans \( K\) tel que
     \begin{equation}
         K\subset\bigcup_{x\in S}V_x.
     \end{equation}
@@ -155,7 +155,7 @@ Quelques liens vers la notion de compacité.
 \begin{proof}
 %    Nous allons utiliser la caractérisation de la compacité en termes de suites donnée par le théorème de Bolzano-Weierstrass \ref{ThoBWFTXAZNH}. Soit \( K\) un compact et \( F\) un fermé dans \( K\). Nous considérons une suite \( (x_n)\) dans \( F\); par la compacité de \( K\) nous pouvons considérer une sous-suite \( (y_n)\) qui converge dans \( K\) (proposition \ref{ThoBWFTXAZNH}). Étant donné que \( (y_n)\) est une suite convergente contenue dans \( F\) et étant donné que \( F\) est fermé, la limite est dans \( F\), ce qui prouve que \( (x_n)\) possède une sous-suite convergente dans $F$ et par conséquent que \( F\) est compact.
  
-    Soit \( F\) fermé dans un compact \( K\) et \( \{ \mO_i \}_{i\in I}\) un recouvrement de \( F\) par des ouverts. Vu que \( F\) est fermé, \( F^c\) est ouvert et \( \{ \mO_i \}_{i\in I}\cup\{ K\setminus F \}\) est un recouvrement de \( K\) par des ouverts. Si nous en extrayons un sous-recouvrement fini, c'est un recouvrement de \( F\), et en supprimant éventuellement l'ouvert \( K\setminus F\), ça reste un sous-recouvrement fini de \( F\) tout en étant extrait de \( \{ \mO_i \}_{i\in I}\).
+    Soient \( F\) fermé dans un compact \( K\) et \( \{ \mO_i \}_{i\in I}\) un recouvrement de \( F\) par des ouverts. Vu que \( F\) est fermé, \( F^c\) est ouvert et \( \{ \mO_i \}_{i\in I}\cup\{ K\setminus F \}\) est un recouvrement de \( K\) par des ouverts. Si nous en extrayons un sous-recouvrement fini, c'est un recouvrement de \( F\), et en supprimant éventuellement l'ouvert \( K\setminus F\), ça reste un sous-recouvrement fini de \( F\) tout en étant extrait de \( \{ \mO_i \}_{i\in I}\).
 \end{proof}
 
 \begin{proposition}     \label{PropGBZUooRKaOxy}
@@ -807,7 +807,7 @@ Une des nombreuses propositions qui vont servir à prouver le théorème des \hr
 
     \item[\( M\) est un intervalle]
 
-        Soit \( m\in M\) et \( m'\in\mathopen[ a , m [\). Le sous-recouvrement fini qui recouvre \( \mathopen[ a , m \mathclose]\) recouvre a fortiori \( \mathopen[ a , m' \mathclose]\).
+        Soient \( m\in M\) et \( m'\in\mathopen[ a , m [\). Le sous-recouvrement fini qui recouvre \( \mathopen[ a , m \mathclose]\) recouvre a fortiori \( \mathopen[ a , m' \mathclose]\).
 
     \item[Les trois possibilités restantes]
         À ce niveau de la preuve, il reste trois possibilités pour \( M\) soit il est de la forme \( \mathopen[ a , c \mathclose]\) ou \( \mathopen[ a , c [\) avec \( c<b\), soit il est de la forme \( \mathopen[ a , b \mathclose]\). Nous allons maintenant éliminer les deux premiers cas.
@@ -948,7 +948,7 @@ Nous aurons une version pour les fonctions croissantes et bornées en la proposi
 
 
 \begin{proposition}		\label{PropContinueCompactBorne}
-	Soient $V$ et $W$ deux espaces vectoriels normés. Soit $K$, une partie compacte de $V$, et $f\colon K\to W$, une fonction continue. Alors l'image $f(K)$ est compacte dans $W$.
+	Soient $V$ et $W$ deux espaces vectoriels normés. Soient $K$ une partie compacte de $V$ et $f\colon K\to W$ une fonction continue. Alors l'image $f(K)$ est compacte dans $W$.
 \end{proposition}
 Ce résultat est démontré dans un cadre plus général par le théorème \ref{ThoImCompCotComp}.
 

--- a/tex/frido/188_EspacesVectos.tex
+++ b/tex/frido/188_EspacesVectos.tex
@@ -311,7 +311,7 @@ Pourquoi nous ne considérons pas la combinaison $(u\cdot v)\times w$ ?
 				\langle u, v\rangle^2 +\| u\times v \|^2=\| u \|^2\| v \|^2
 			\end{equation}
 		\item
-			Par rapport à la dérivation, le produit scalaire et vectoriel vérifient une règle de Leibnitz. Soit $I$ un intervalle de $\eR$, et si $u$ et $u$ sont dans $C^1(I,\eR^3)$, alors
+			Par rapport à la dérivation, le produit scalaire et vectoriel vérifient une règle de Leibnitz. Soit $I$ un intervalle de $\eR$. Si $u$ et $u$ sont dans $C^1(I,\eR^3)$, alors
 			\begin{equation}		\label{EqFormLeibProdscalVect}
 				\begin{aligned}[]
 					\frac{ d }{ dt }\big( u(t)\cdot v(t) \big)&=\big( u'(t)\cdot v(t) \big)+\big( u(t)\cdot v'(t) \big)\\

--- a/tex/frido/189_mesure.tex
+++ b/tex/frido/189_mesure.tex
@@ -523,7 +523,7 @@ Une dilatation d'un facteur \( a\) des longueurs provoque une multiplication par
                 \end{equation}
                 La dernière inégalité est le fait que les intersections ne sont pas disjointes. Toutes ces inégalités sont en réalité des égalités et en particulier : \( \lambda_N(Q)=\sum_i\lambda_N(Q_i)\).
 
-                Soit \( a\in Q_i\) et posons
+                Soit \( a\in Q_i\). Posons
                 \begin{equation}
                     \begin{aligned}
                         \theta&\colon U&\to U \\
@@ -656,7 +656,7 @@ Une dilatation d'un facteur \( a\) des longueurs provoque une multiplication par
             Le fait que la fonction proposée soit mesurable est le fait que la mesurabilité n'est pas affectée par produit et composition (propositions \ref{PROPooODDVooEEmmTX} et \ref{PROPooEFHKooARJBwW}), et le fait que pour les mêmes raisons, l'application \( J_{\phi}\colon U\to \eR\) est également mesurable. En ce qui concerne la formule nous allons la démontrer dans le cas de fonctions de plus en plus générales.
             \begin{subproof}
             \item[Pour les fonctions indicatrices]
-                Soit \( B\) un borélien de \( U\), et considérons la fonction \( f=\mtu_{\phi(B)}\). Alors
+                Soit \( B\) un borélien de \( U\). Considérons la fonction \( f=\mtu_{\phi(B)}\). Alors
                 \begin{equation}    \label{EqYXRFooJEqVBH}
                         \int_V fd\lambda_N=\int_{\eR^N}\mtu_{\phi(B)}(y)\mtu_V(y)d\lambda_N(y)
                         =\int_{\eR^N}\mtu_{\phi(B)}d\lambda_N

--- a/tex/frido/193_numerique.tex
+++ b/tex/frido/193_numerique.tex
@@ -7,7 +7,7 @@
 \section{Problèmes de dimension un}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Soit une fonction \( u\colon \eR\to \eR\), et soit \( h>0\). Nous définissons les opérations suivantes (qui sont supposées approximer la dérivée \( u'(x)\) lorsqu'elle existe).
+Soit \( u\colon \eR\to \eR\) une fonction et \( h>0\). Nous définissons les opérations suivantes (qui sont supposées approximer la dérivée \( u'(x)\) lorsqu'elle existe).
 
 \begin{definition}
     La \defe{différence progressive}{différence!progressive} est 
@@ -129,7 +129,7 @@ Utilisant l'expression \eqref{EQooBLIIooWHXbqD} pour \( D^-D^+\) nous avons l'é
 \begin{equation}        \label{EQooECLXooFxZEeA}
     \frac{1}{ h^2 }\Big( 2u_h(x)-u_h(x+h)-u_h(x-h) \Big)+c(x)u_h(x)=f(x).
 \end{equation}
-Avons-nous gagné quelque chose ? Pas encore. L'idée est de la discrétisation est de ne considérer \( u_h\) qu'en certains points, écartés de \( h\). Soit donc un nombre entier \( N\) et \( h=1/(N+1)\). Nous posons
+Avons-nous gagné quelque chose ? Pas encore. L'idée est de la discrétisation est de ne considérer \( u_h\) qu'en certains points, écartés de \( h\). Soient donc \( N\) un nombre entier et \( h=1/(N+1)\). Nous posons
 \begin{equation}
     x_k=kh
 \end{equation}

--- a/tex/frido/2_Integration.tex
+++ b/tex/frido/2_Integration.tex
@@ -226,7 +226,7 @@ Le plus souvent, pour alléger les notations, il est plus pratique d'utiliser l'
 
 De la même manière que l'utilisation «à l'envers» de la formule de dérivation du produit avait donné la méthode d'intégration par parties, nous allons voir que que l'utilisation «à l'envers» de la formule de dérivation d'une fonction composée donne lieu à la méthode d'intégration par changement de variables.
 \begin{proposition}
-    Soit \( I\) et \( J\) des intervalles de \( \eR\) et une fonction \( u\colon I\to J\) qui est dérivable de dérivée continue. Soit \( f\colon J\to \eR\) une fonction admettant une primitive \( F\). Alors la fonction
+    Soient \( I\) et \( J\) des intervalles de \( \eR\), \( u\colon I\to J\) une fonction qui est dérivable de dérivée continue et \( f\colon J\to \eR\) une fonction admettant une primitive \( F\). Alors la fonction
     \begin{equation}
         x\mapsto F\big( u(x) \big)
     \end{equation}

--- a/tex/frido/38_Integration.tex
+++ b/tex/frido/38_Integration.tex
@@ -1261,7 +1261,7 @@ Pourquoi ces «nouvelles» coordonnées sphériques sont-elles mauvaises ? Il y 
 \section{Aire et primitive}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Soit $f\colon \eR\to \eR$, une fonction continue, et $x\in\eR$. Pour chaque $x\in\eR$, nous pouvons considérer le nombre $F(x)$ défini par
+Soient $f\colon \eR\to \eR$ une fonction continue et $x\in\eR$. Pour chaque $x\in\eR$, nous pouvons considérer le nombre $F(x)$ défini par
 \begin{equation}
 	F(x)=\int_a^x f(t)dt.
 \end{equation}

--- a/tex/frido/41_mesure.tex
+++ b/tex/frido/41_mesure.tex
@@ -12,7 +12,7 @@
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{definition}[Fonction mesurable] \label{DefQKjDSeC}
-    Soit \( (E,\tribA)\) et \( (F,\tribF)\) deux espaces mesurés. Une fonction \( f\colon E\to F\) est \defe{mesurable}{mesurable!fonction} si pour tout \( \mO\in \tribF\), l'ensemble \( f^{-1}(\mO)\) est dans \( \tribA\).
+    Soient \( (E,\tribA)\) et \( (F,\tribF)\) deux espaces mesurés. Une fonction \( f\colon E\to F\) est \defe{mesurable}{mesurable!fonction} si pour tout \( \mO\in \tribF\), l'ensemble \( f^{-1}(\mO)\) est dans \( \tribA\).
 \end{definition}
 
 \begin{definition}[Fonction borélienne]     \label{DefHHIBooNrpQjs}

--- a/tex/frido/48_StructAnneaux.tex
+++ b/tex/frido/48_StructAnneaux.tex
@@ -106,7 +106,7 @@ La proposition suivante donne une caractérisation d'un corps, en disant un tout
 \end{proof}
 
 \begin{definition}      \label{DEFooTCUOooWHlbee}
-    Soit \( A\) un anneau et \( a,b\in A\). Nous disons que \( d\) est un \( \pgcd\)\index{pgcd} de \( a\) et \( b\) si tout diviseur commun de \( a\) et \( b\) divise \( d\).
+    Soient \( A\) un anneau et \( a,b\in A\). Nous disons que \( d\) est un \( \pgcd\)\index{pgcd} de \( a\) et \( b\) si tout diviseur commun de \( a\) et \( b\) divise \( d\).
 \end{definition}
 
 Nous rappelons également la définition \ref{DEFooQBGJooKJqHXr} de morphisme d'anneaux. Remarquons que si \( f\) est un morphisme, nous avons \( f(0)=0\) et \( f(x)^{-1}=f(x^{-1})\).
@@ -212,7 +212,7 @@ est un anneau appelé \defe{anneau quotient}{anneau!quotient par un idéal}. La 
 \index{théorème!isomorphisme!premier!pour les anneaux}
 
 \begin{proposition}     \label{PropIJJIdsousphi}
-    Soit \( I\), un idéal de \( A\) et \( \phi\colon A\to A/I\) la surjection canonique. Les idéaux de \( A/I\) sont les \( \phi(J)\) où \( J\) est un idéal de \( A\) contenant \( I\). De plus cette relation est bijective :
+    Soient \( I\) un idéal de \( A\) et \( \phi\colon A\to A/I\) la surjection canonique. Les idéaux de \( A/I\) sont les \( \phi(J)\) où \( J\) est un idéal de \( A\) contenant \( I\). De plus cette relation est bijective :
     \begin{equation}        \label{EqKbrizu}
         \{ \text{idéaux de } A\text{ contenant } I\}\simeq\{ \text{idéaux de } A/I \}.
     \end{equation}
@@ -224,7 +224,7 @@ est un anneau appelé \defe{anneau quotient}{anneau!quotient par un idéal}. La 
         \phi(i)\phi(j)=\phi(ij)\in\phi(J).
     \end{equation}
     
-    Soit maintenant \( K\), un idéal dans \( A/I\). Soit \( J=\phi^{-1}(K)\). Étant donné qu'un idéal doit contenir \( 0\) (parce qu'un idéal est un groupe pour l'addition), \( [0]\in K\) et par conséquent \( I\subset\phi^{-1}(K)\).
+    Soit maintenant \( K\) un idéal dans \( A/I\) et soit \( J=\phi^{-1}(K)\). Étant donné qu'un idéal doit contenir \( 0\) (parce qu'un idéal est un groupe pour l'addition), \( [0]\in K\) et par conséquent \( I\subset\phi^{-1}(K)\).
 \end{proof}
 % TODO : il faudrait dire à peu près ici qu'une des utilités de Z_2 est le groupe modulaire PSL(2,Z)=SL(2,Z)/Z_2
 
@@ -242,7 +242,7 @@ est un anneau appelé \defe{anneau quotient}{anneau!quotient par un idéal}. La 
 \end{proof}
 
 \begin{proposition}     \label{PropZpintssiprempUzn}
-    Soit \( n\geq 2\) un entier et \( \phi\colon \eZ\to \eZ/n\eZ\), la surjection canonique. Nous noterons \( \tilde a=\phi(a)\). Alors l'ensemble des inversibles de \( \eZ/n\eZ\) est donné par
+    Soient \( n\geq 2\) un entier et \( \phi\colon \eZ\to \eZ/n\eZ\) la surjection canonique. Nous noterons \( \tilde a=\phi(a)\). Alors l'ensemble des inversibles de \( \eZ/n\eZ\) est donné par
     \begin{equation}
         U(\eZ/n\eZ)=\phi(P_n)=\{ \tilde x\tq 0\leq x\leq n\tq\pgcd(x,n)=1 \}.
     \end{equation}
@@ -256,7 +256,7 @@ est un anneau appelé \defe{anneau quotient}{anneau!quotient par un idéal}. La 
     \end{equation}
     donc \( \tilde u\) est l'inverse de \( \tilde x\). Cela prouve que \( \phi(P_n)\subset U(\eZ/n\eZ)\).
 
-    Nous prouvons maintenant l'inclusion inverse. Soit \( \tilde x\) et \( \tilde y\) inverses l'un de l'autre : $\tilde x\tilde y=\tilde 1$. Il existe donc \( q\in\eZ\) tel que \( xy-qn=1\), ce qui prouve\footnote{À nouveau avec le Théorème de Bézout.} que \( \pgcd(x,n)=1\).
+    Nous prouvons maintenant l'inclusion inverse. Soient \( \tilde x\) et \( \tilde y\) inverses l'un de l'autre : $\tilde x\tilde y=\tilde 1$. Il existe donc \( q\in\eZ\) tel que \( xy-qn=1\), ce qui prouve\footnote{À nouveau avec le Théorème de Bézout.} que \( \pgcd(x,n)=1\).
 \end{proof}
 
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ 
@@ -381,7 +381,7 @@ Si \( A\) est un anneau et si \( (M,+)\) est un groupe commutatif, nous disons q
     La notion de module généralise celle d'espace vectoriel que nous verrons plus loin.
 \end{remark}
 
-Soit \( M\) un \( A\)-module et \( x=(x_i)_{i\in I}\) une famille d'éléments de \( M\), paramétrée par l'ensemble \( I\). Nous considérons l'application
+Soient \( M\) un \( A\)-module et \( x=(x_i)_{i\in I}\) une famille d'éléments de \( M\) paramétrée par l'ensemble \( I\). Nous considérons l'application
 \begin{equation}
     \begin{aligned}
         \mu_x\colon A^{(I)}&\to M \\
@@ -458,7 +458,7 @@ Un module simple est a fortiori indécomposable. L'inverse n'est pas vrai comme 
 \end{definition}
 
 \begin{lemma}[\cite{MonCerveau}]   \label{LEMooVKLKooSAHmpZ}
-    Soit une algèbre \( A\) et une famille \( (X_i)_{i\in I}\) de sous-algèbres de \( A\) (ici \( I\) est un ensemble quelconque). Alors la partie \( X=\bigcap_{i\in I}X_i\) est une sous-algèbre de \( A\).
+    Soient une algèbre \( A\) et une famille \( (X_i)_{i\in I}\) de sous-algèbres de \( A\) (ici \( I\) est un ensemble quelconque). Alors la partie \( X=\bigcap_{i\in I}X_i\) est une sous-algèbre de \( A\).
 \end{lemma}
 
 \begin{proof}
@@ -613,7 +613,7 @@ Commençons par donner une autre vision de la divisibilité dans les anneaux int
 Donc la divisibilité devient en réalité une relation d'ordre dont nous pouvons chercher un maximum et un minimum. Si \( S\) est une partie de \( A\), nous notons \( a\divides S\) pour exprimer que \( a\divides x\) pour tout \( x\in S\); de la même façon, \( S\divides b\) signifie que \( x\divides b\) pour tout \( x\in S\)
 
 \begin{definition}\label{DefrYwbct}
-    Soit \( A\), un anneau intègre et \( S\subset A\). Nous disons que \( \delta\in A\) est un \defe{PGCD}{PGCD!dans un anneau intègre} de \( S\) si
+    Soient \( A\) un anneau intègre et \( S\subset A\). Nous disons que \( \delta\in A\) est un \defe{PGCD}{PGCD!dans un anneau intègre} de \( S\) si
     \begin{enumerate}
         \item
             \( \delta\divides S\)
@@ -631,13 +631,13 @@ Donc la divisibilité devient en réalité une relation d'ordre dont nous pouvon
 Notons qu'il n'y a en général pas unicité du PGCD ou du PPCM d'un ensemble.
 
 \begin{lemma}
-    Soit \( A\) un anneau intègre et \( S\subset A\). Si \( \delta\) est un PGCD de \( S\), alors l'ensemble des PGCD de \( S\) est la classe d'association de \( \delta\).
+    Soent \( A\) un anneau intègre et \( S\subset A\). Si \( \delta\) est un PGCD de \( S\), alors l'ensemble des PGCD de \( S\) est la classe d'association de \( \delta\).
 
     De la même façon si \( \mu\) est un PPCM de \( S\), alors l'ensemble des PPCM de \( S\) est la classe d'association de \( \mu\).
 \end{lemma}
 
 \begin{proof}
-    Soit \( \delta\) un PGCD de \( S\) et \( u\) un inversible dans \( A\). Si \( x\in S\) nous avons \( \delta\divides x\) et donc \( x=a\delta\). Par conséquent \( x=au^{-1}u\delta\) et donc \( u\delta\) divise \( x\). De la même manière, si \( d\) divise \( x\) pour tout \( x\in S\), alors \( d\) divise \( \delta\) et donc \( \delta=ad\) et \( u\delta=aud\), ce qui signifie que \( d\) divise \( u\delta\).
+    Soient \( \delta\) un PGCD de \( S\) et \( u\) un inversible dans \( A\). Si \( x\in S\) nous avons \( \delta\divides x\) et donc \( x=a\delta\). Par conséquent \( x=au^{-1}u\delta\) et donc \( u\delta\) divise \( x\). De la même manière, si \( d\) divise \( x\) pour tout \( x\in S\), alors \( d\) divise \( \delta\) et donc \( \delta=ad\) et \( u\delta=aud\), ce qui signifie que \( d\) divise \( u\delta\).
 
     Dans l'autre sens nous devons prouver que si \( \delta'\) est un autre PGCD de \( S\), alors il existe un inversible \( u\in \eA\) tel que \( \delta'=u\delta\). Vu que \( \delta'\) divise \( x\) pour tout \( x\in S\), nous avons \( \delta'\divides \delta\), et symétriquement nous trouvons \( \delta\divides\delta'\). Par conséquent (lemme \ref{LemRmVTRq}), il existe un inversible \( u\) tel que \( \delta=u\delta'\).
 
@@ -712,7 +712,7 @@ Il faut être un peu souple avec les notations : ici \( b(ac)\) est le produit d
 \end{proposition}
 
 \begin{proposition}
-    Soit \( A\), un anneau commutatif non nul et \( I\), un idéal dans \( A\). L'ensemble \( I\) est un idéal maximal de \( A\) si et seulement si \( A/I\) est un corps.
+    Soient \( A\) un anneau commutatif non nul et \( I\) un idéal dans \( A\). L'ensemble \( I\) est un idéal maximal de \( A\) si et seulement si \( A/I\) est un corps.
 \end{proposition}
 
 \begin{proof}
@@ -1695,7 +1695,7 @@ Lorsque nous utiliserons la notion de polynôme primitif au sens du \( \pgcd\), 
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{definition}
-  Soit \( A \) un anneau, et \( P \in A[X] \). On appelle
+  Soient \( A \) un anneau et \( P \in A[X] \). On appelle
   \defe{racine}{racine!d'un polynôme} un élément \( \alpha \in A \)
   tel que \( P(\alpha) = 0 \); c'est-à-dire que, en remplaçant toutes
   les occurrences de $X$ par $\alpha$ dans l'expression de $P$, on
@@ -1703,7 +1703,7 @@ Lorsque nous utiliserons la notion de polynôme primitif au sens du \( \pgcd\), 
 \end{definition}
 
 \begin{proposition} \label{PropHSQooASRbeA}
-    Soit \( A\) un anneau et \( P\) un polynôme non nul dans \( A[X]\). Si \( \alpha\in A\) est une racine de \( P\) alors \( X-\alpha\) divise \( P\), et réciproquement.
+    Soient \( A\) un anneau et \( P\) un polynôme non nul dans \( A[X]\). Si \( \alpha\in A\) est une racine de \( P\) alors \( X-\alpha\) divise \( P\), et réciproquement.
 \end{proposition}
 
 \begin{proof}
@@ -1782,7 +1782,7 @@ La proposition \ref{PropHSQooASRbeA} nous indique que toute racine est de multip
 \end{proof}
 
 \begin{corollary}[Conséquence du lemme de Gauss\cite{ooCDLEooEQGSvn}]       \label{CORooZCSOooHQVAOV}
-    Soit \( A\) un anneau factoriel et \( \Frac(A)\) son corps des fractions. Un polynôme non constant \( P\in A[X]\) est irréductible (sur \( A\)) si et seulement s'il est irréductible et primitif au sens du pgcd\footnote{Définition \ref{DEFooAIYGooRAEfHU}.} sur \( \Frac(A)[X]\). 
+    Soient \( A\) un anneau factoriel et \( \Frac(A)\) son corps des fractions. Un polynôme non constant \( P\in A[X]\) est irréductible (sur \( A\)) si et seulement s'il est irréductible et primitif au sens du pgcd\footnote{Définition \ref{DEFooAIYGooRAEfHU}.} sur \( \Frac(A)[X]\). 
 \end{corollary}
 
 %--------------------------------------------------------------------------------------------------------------------------- 

--- a/tex/frido/50_StructCorps.tex
+++ b/tex/frido/50_StructCorps.tex
@@ -1058,7 +1058,7 @@ Le corollaire suivant va être utilisé pour déterminer les polygones construct
 \end{lemma}
 
 \begin{proof}
-    Soit \( n\geq 1\) et les nombres \( p,a\) donnés par le lemme \ref{LemiAqLEn}. Vu que \( p\) divise \( \phi_n(a)\), \( p\) divise \( a^n-1\) et donc \( [a]_p\) a un ordre qui divise \( n\) dans \( (\eZ/p\eZ)^*\) parce que \( [a]_p^n=[1]_p\).
+    Soient \( n\geq 1\) et \( p,a\) les nombres donnés par le lemme \ref{LemiAqLEn}. Vu que \( p\) divise \( \phi_n(a)\), \( p\) divise \( a^n-1\) et donc \( [a]_p\) a un ordre qui divise \( n\) dans \( (\eZ/p\eZ)^*\) parce que \( [a]_p^n=[1]_p\).
 
     Prenons \( d\neq n\) divisant \( n\). Nous savons que
     \begin{equation}

--- a/tex/frido/53_topologie.tex
+++ b/tex/frido/53_topologie.tex
@@ -559,7 +559,7 @@ Les distances que nous avons vues jusqu'à présent sont des distances définies
     \begin{equation}
         | \frac{1}{ n }-\frac{1}{ m } |<\frac{1}{ n }<\frac{1}{ N }<\epsilon.
     \end{equation}
-    Or cette suite ne converge pas. Soit en effet un candidat limite \( k\) et calculons
+    Or cette suite ne converge pas. Soit en effet un candidat limite \( k\). Calculons
     \begin{equation}
         d_1(x_n,k)=| \frac{1}{ n }-\frac{1}{ k } |\to \frac{1}{ k }\neq 0.
     \end{equation}
@@ -628,7 +628,7 @@ Les distances que nous avons vues jusqu'à présent sont des distances définies
     Et juste pour faire simple nous notons \( V_0=X\).
     \begin{subproof}
         \item[Les parties \( V_n\) sont ouvertes]
-            Soit \( x\in V_n\) et trouvons un voisinage de \( x\) contenu dans \( V_n\) -- encore le théorème \ref{ThoPartieOUvpartouv}. Si \( y\in B(x,\epsilon)\) alors il existe \( a\in A\) tel que \( d(x,a)<\frac{1}{ n }\) (ici les inégalités strictes sont importantes) et donc
+            Soit \( x\in V_n\). Trouvons un voisinage de \( x\) contenu dans \( V_n\) -- encore le théorème \ref{ThoPartieOUvpartouv}. Si \( y\in B(x,\epsilon)\) alors il existe \( a\in A\) tel que \( d(x,a)<\frac{1}{ n }\) (ici les inégalités strictes sont importantes) et donc
             \begin{equation}
                 d(y,a)\leq d(y,x)+d(x,a)<\epsilon+\frac{1}{ n }.
             \end{equation}
@@ -800,7 +800,7 @@ Tant sur \( \eQ\) que sur \( \eR\), nous considérons la topologie métrique cor
 \index{densité!de \( \eQ\) dans \( \eR\)}
 
 \begin{proof}
-    Soit \( r\in \eR\) et \( \epsilon\in \eR^+\). Nous devons prouver l'existence d'un rationnel dans \( B(x,\epsilon)\). Le lemme \ref{LemooHLHTooTyCZYL} dit qu'il existe un rationnel dans \( \mathopen] x-\epsilon/2 , x+\epsilon/2 \mathclose[\) et donc dans \( B(x,\epsilon)\).
+    Soient \( r\in \eR\) et \( \epsilon\in \eR^+\). Nous devons prouver l'existence d'un rationnel dans \( B(x,\epsilon)\). Le lemme \ref{LemooHLHTooTyCZYL} dit qu'il existe un rationnel dans \( \mathopen] x-\epsilon/2 , x+\epsilon/2 \mathclose[\) et donc dans \( B(x,\epsilon)\).
 \end{proof}
 
 
@@ -809,7 +809,7 @@ Tant sur \( \eQ\) que sur \( \eR\), nous considérons la topologie métrique cor
 \end{proposition}
 
 \begin{proof}
-    Soit \( x\in \eR\) et \( \delta\in \eR\); vu que \( x-\delta\) et \( x\) sont des réels, le lemme \ref{LemooHLHTooTyCZYL} donne un élément \( x_{\delta}\) tel que 
+    Soient \( x\in \eR\) et \( \delta\in \eR\); vu que \( x-\delta\) et \( x\) sont des réels, le lemme \ref{LemooHLHTooTyCZYL} donne un élément \( x_{\delta}\) tel que 
     \begin{equation}
         x-2\delta<x_{\delta}<x.
     \end{equation}
@@ -848,7 +848,7 @@ Tant sur \( \eQ\) que sur \( \eR\), nous considérons la topologie métrique cor
 \index{base!de topologie!dénombrable}
 
 \begin{proof}
-    Soit \( x\in E\) et \( V\) un voisinage de \( x\). Ce dernier contient une boule \( B(x,r)\) et quitte à prendre \( r\) un peu plus petit nous supposons que \( r\in \eQ\) (densité de \( \eQ\) dans \( \eR\), proposition \ref{PropooUHNZooOUYIkn}).
+    Soient \( x\in E\) et \( V\) un voisinage de \( x\). Ce dernier contient une boule \( B(x,r)\) et quitte à prendre \( r\) un peu plus petit nous supposons que \( r\in \eQ\) (densité de \( \eQ\) dans \( \eR\), proposition \ref{PropooUHNZooOUYIkn}).
 
     Soit \( a\in A\) avec \( \| a-x \|<\frac{ r }{ 3 }\) (existe par densité de \( A\) dans \( E\)); nous avons \( B(a,\frac{ 2r }{ 3 })\subset B(x,r)\) parce que si \( y\in B( a,\frac{ 2r }{ 3 } )\) alors
     \begin{equation}

--- a/tex/frido/54_topologieR.tex
+++ b/tex/frido/54_topologieR.tex
@@ -26,7 +26,7 @@
 
 La propriété suivante donne des caractérisations importantes de la continuité dans le cas des espaces métriques.
 \begin{proposition}[Continuité, ouverts et voisinages et limite\cite{DHpsZoY}] \label{PropQZRNpMn}
-    Soit \( f\colon E\to F\) une application entre espaces métriques et \( a\in E\). Alors nous avons équivalence entre les choses suivantes :
+    Soient \( f\colon E\to F\) une application entre espaces métriques et \( a\in E\). Alors nous avons équivalence entre les choses suivantes :
     \begin{enumerate}
         \item\label{ItemCBUoRWJi}
             \( f\) est continue en \( a\),
@@ -54,7 +54,7 @@ La proposition \ref{PropNGjQnqF} nous montrera que ces équivalences tiennent en
 
     L'équivalence \ref{ItemCBUoRWJi} \( \Leftrightarrow\) \ref{ItemYNQpikrii} est la définition \ref{DefOLNtrxB} de la continuité en un point couplée à l'unicité de la limite due à la proposition \ref{PropFObayrf} parce qu'un espace métrique est séparé.
 
-    Prouvons \ref{ItemYNQpikrii} \( \Rightarrow\) \ref{ItemYNQpikriii}. Soit \( \epsilon>0\) et \( V=B\big( f(a),\epsilon \big)\). Étant donné que \( f(a)\) est une limite de \( f\) pour \( x\to a\), il existe un voisinage \( W\) de \( a\) tel que \( f(W)\subset V\). Soit \( \delta>0\) tel que \( B(a,\delta)\subset W\); alors si \( \| x-a \|<\delta\) nous avons \( x\in B(x,\delta)\subset W\) et donc \( f(x)\in B\big( f(a),\epsilon \big)\), c'est à dire \( \| f(a)-f(x) \|<\epsilon\).
+    Prouvons \ref{ItemYNQpikrii} \( \Rightarrow\) \ref{ItemYNQpikriii}. Soient \( \epsilon>0\) et \( V=B\big( f(a),\epsilon \big)\). Étant donné que \( f(a)\) est une limite de \( f\) pour \( x\to a\), il existe un voisinage \( W\) de \( a\) tel que \( f(W)\subset V\). Soit \( \delta>0\) tel que \( B(a,\delta)\subset W\); alors si \( \| x-a \|<\delta\) nous avons \( x\in B(x,\delta)\subset W\) et donc \( f(x)\in B\big( f(a),\epsilon \big)\), c'est à dire \( \| f(a)-f(x) \|<\epsilon\).
 
     Enfin l'implication \ref{ItemCBUoRWJii} \( \Rightarrow\) \ref{ItemYNQpikrii} est une réécriture de la définition de la limite en un point.
 \end{proof}
@@ -64,7 +64,7 @@ La proposition \ref{PropNGjQnqF} nous montrera que ces équivalences tiennent en
 \end{proposition}
 
 \begin{proof}
-    Soient \( f\colon X\to Y\), une application isométrique et \( \mO\) un ouvert de \( Y\). Soit \( a\in f^{-1}(\mO)\); si \( d(a,b)<r\), alors \( d\big( f(a),f(b) \big)<r\) et donc \( b\in f^{-1}\big( B(f(a),r) \big)\). Donc autour de chaque point de \( f^{-1}(\mO)\) nous pouvons trouver une boule ouverte contenue dans \( f^{-1}(\mO)\), ce qui prouve que \( f^{-1}(\mO)\) est ouvert.
+    Soient \( f\colon X\to Y\) une application isométrique et \( \mO\) un ouvert de \( Y\). Soit \( a\in f^{-1}(\mO)\); si \( d(a,b)<r\), alors \( d\big( f(a),f(b) \big)<r\) et donc \( b\in f^{-1}\big( B(f(a),r) \big)\). Donc autour de chaque point de \( f^{-1}(\mO)\) nous pouvons trouver une boule ouverte contenue dans \( f^{-1}(\mO)\), ce qui prouve que \( f^{-1}(\mO)\) est ouvert.
 \end{proof}
 
 \begin{theorem}[Théorème \wikipedia{fr}{Théorème_des_fermés_emboités}{des fermés emboîtés}\cite{OIywOjl}]   \label{ThoCQAcZxX}
@@ -81,7 +81,7 @@ La proposition \ref{PropNGjQnqF} nous montrera que ces équivalences tiennent en
 
     \item[Condition nécessaire]
 
-        Soit une suite de Cauchy \( (x_n)\). Nous considérons les ensembles
+        Soit \( (x_n)\) un suite de Cauchy. Nous considérons les ensembles
         \begin{equation}
             F_n=\overline{ \{ x_i\tq i\geq n \} }.
         \end{equation}
@@ -124,7 +124,7 @@ Une fonction continue est séquentiellement continue. Dans les espaces métrique
 \begin{proof}
     \begin{subproof}
     \item[Sens direct]
-        Supposons que \( f\) soit continue en \( a\) et considérons une suite \( a_k\to a\). Soit \( V\) un voisinage de \( f(a)\) et \( W\) un voisinage de \( a\) tel que \( f(W)\subset V\) (définition \ref{DefYNVoWBx} de la continuité en un point). Par la convergence \( a_k\to a\),  il existe \( N\) tel que pour tout \( k>N\), \( a_k\in W\), et donc tel que \( f(a_k)\in V\), ce qui donne la continuité séquentielle de \( f\).
+        Supposons que \( f\) soit continue en \( a\) et considérons une suite \( a_k\to a\). Soient \( V\) un voisinage de \( f(a)\) et \( W\) un voisinage de \( a\) tels que \( f(W)\subset V\) (définition \ref{DefYNVoWBx} de la continuité en un point). Par la convergence \( a_k\to a\),  il existe \( N\) tel que pour tout \( k>N\), \( a_k\in W\), et donc tel que \( f(a_k)\in V\), ce qui donne la continuité séquentielle de \( f\).
     \item[Sens réciproque, espaces métriques]
 
         Nous supposons maintenant que \( X\) et \( Y\) soient métriques. Si \( f\) n'est pas continue en \( a\), il existe \( \epsilon>0\) tel que pour tout \( \delta>0\), il existe \( x\) tel que \( \| x-a \|\leq\delta\) et \( \| f(x)-f(a) \|>\epsilon\). Nous considérons un tel \( \epsilon\) et pour chaque \( n\geq1\in \eN\) nous considérons un \( x_n\) correspondant à \( \delta=\frac{1}{ n }\). Cela nous donne une suite \( x_n\to a\) dans \( X\) mais \( \| f(x_n) -f(a)\|\) reste plus grand que \( \epsilon\). Cela montre que \( f\) n'est pas non plus séquentiellement continue.
@@ -133,18 +133,18 @@ Une fonction continue est séquentiellement continue. Dans les espaces métrique
 
 Les espaces métriques ont une propriété importante que la \wikipedia{fr}{Espace_séquentiel}{fermeture séquentielle} est équivalente à la fermeture.
 \begin{proposition}[Caractérisation séquentielle d'un fermé]    \label{PropLFBXIjt}
-    Soit \( X\) un espace métrique et \( F\subset X\). L'ensemble \( F\) est fermé si et seulement si toute suite contenue dans \( F\) et convergeant dans \( X\) converge vers un élément de \( F\).
+    Soient \( X\) un espace métrique et \( F\subset X\). L'ensemble \( F\) est fermé si et seulement si toute suite contenue dans \( F\) et convergeant dans \( X\) converge vers un élément de \( F\).
 \end{proposition}
 \index{fermeture!séquentielle}
 
 \begin{proof}
-    Si \( F\) est fermé alors \( X\setminus F\) est ouvert. Soit une suite \( x_n\stackrel{X}{\longrightarrow}x\) contenue dans \( F\). Si \( A\) est un ouvert autour de \( x\) contenu dans \( X\setminus F\) (existence par le théorème \ref{ThoPartieOUvpartouv}), alors la suite ne peut pas entrer dans \( A\) et ne peut donc pas converger vers \( x\).
+    Si \( F\) est fermé alors \( X\setminus F\) est ouvert. Soit \( x_n\stackrel{X}{\longrightarrow}x\) une suite à valeurs dans \( F\). Si \( A\) est un ouvert autour de \( x\) contenu dans \( X\setminus F\) (existence par le théorème \ref{ThoPartieOUvpartouv}), alors la suite ne peut pas entrer dans \( A\) et ne peut donc pas converger vers \( x\).
 
     Dans l'autre sens maintenant. Supposons que \( X\setminus F\) ne soit pas ouvert. Alors il existe \( x\in X\setminus F\) pour lequel tout voisinage intersecte \( F\). En prenant \( x_k\in B(x,\frac{1}{ k })\), nous construisons une suite contenue dans \( F\) qui converge vers \( x\).
 \end{proof}
 
 \begin{proposition} \label{PropXIAQSXr}
-    Soient deux espaces métriques \( E\) et \( Y\). Soit \( f\colon E\to Y\) une application séquentiellement continue. Alors \( f\) est continue.
+    Soient \( E\) et \( Y\) deux espaces métriques. Soit \( f\colon E\to Y\) une application séquentiellement continue. Alors \( f\) est continue.
 \end{proposition}
 
 \begin{proof}
@@ -160,7 +160,7 @@ Les espaces métriques ont une propriété importante que la \wikipedia{fr}{Espa
 \end{proposition}
 
 \begin{proof}
-    Soit \( E\) un espace métrique et un homéomorphisme \( \phi\colon X\to (E,d)\). Nous supposons que \( f\colon X\to Y\) est séquentiellement continue. Nous considérons l'application \( \tilde f=f\circ\phi^{-1}\), c'est à dire
+    Soient \( E\) un espace métrique et \( \phi\colon X\to (E,d)\) un homéomorphisme. Nous supposons que \( f\colon X\to Y\) est séquentiellement continue. Nous considérons l'application \( \tilde f=f\circ\phi^{-1}\), c'est à dire
     \begin{equation}
         \begin{aligned}
             \tilde f\colon E&\to Y \\
@@ -184,7 +184,7 @@ Les espaces métriques ont une propriété importante que la \wikipedia{fr}{Espa
 \index{fonction!continue!égales}
 
 \begin{proof}
-    Les fonctions \( f\) et \( g\) sont séquentiellement continues (proposition \ref{PropFnContParSuite}\ref{ItemWJHIooMdugfu}). Soit \( A\) un ensemble dense dans \( X\) sur lequel \( f\) et \( g\) sont égales, et \( x\notin A\). Vu que \( A\) est dense, il existe une suite \( a_n\) dans \( A\) telle que \( a_n\to x\). La séquentielle continuité de \( f\) et \( g\) donnent
+    Les fonctions \( f\) et \( g\) sont séquentiellement continues (proposition \ref{PropFnContParSuite}\ref{ItemWJHIooMdugfu}). Soient \( A\) un ensemble dense dans \( X\) sur lequel \( f\) et \( g\) sont égales, et \( x\notin A\). Vu que \( A\) est dense, il existe une suite \( a_n\) dans \( A\) telle que \( a_n\to x\). La séquentielle continuité de \( f\) et \( g\) donnent
     \begin{subequations}
         \begin{align}
             f(a_n)\to f(x)\\
@@ -209,7 +209,7 @@ Les espaces métriques ont une propriété importante que la \wikipedia{fr}{Espa
 \input{auto/pictures_tex/Fig_DistanceEnsemble.pstricks}
 
 \begin{proposition}     \label{PropGULUooNzqZKj}
-    Soit \( (X,d) \) un espace topologique métrique et \( F\) un fermé de \( X\). Nous avons \( d(x,F)=0\) si et seulement si \( x\in F\).
+    Soient \( (X,d) \) un espace topologique métrique et \( F\) un fermé de \( X\). Nous avons \( d(x,F)=0\) si et seulement si \( x\in F\).
 \end{proposition}
 
 \begin{proof}
@@ -253,7 +253,7 @@ Les espaces métriques ont une propriété importante que la \wikipedia{fr}{Espa
 Une version dédiée à \( \eR^n\) sera démontrée dans le théorème \ref{ThoBolzanoWeierstrassRn}.
 
 \begin{proof}
-   Soit \( X\) un espace métrique compact et \( (x_n)\) une suite dans \( X\). Nous considérons la suite de fermés emboités
+   Soient \( X\) un espace métrique compact et \( (x_n)\) une suite dans \( X\). Nous considérons la suite de fermés emboités
    \begin{equation}
        X_n=\overline{ \{ x_k\tq k>n \} }.
    \end{equation}
@@ -276,7 +276,7 @@ Le théorème de Bolzano–Weierstrass \ref{ThoBWFTXAZNH} a l'importante conséq
 \index{compact!et fonction continue}
 
 \begin{proof}
-	Soit $K$ un compact et $f\colon K\to \eR$ une fonction continue. Nous désignons par $A$ l'ensemble des valeurs prises par $f$ sur $K$ :
+	Soient $K$ un compact et $f\colon K\to \eR$ une fonction continue. Nous désignons par $A$ l'ensemble des valeurs prises par $f$ sur $K$ :
 	\begin{equation}
 		A=f(K)=\{ f(x)\tq x\in K \}.
 	\end{equation}
@@ -357,7 +357,7 @@ Le théorème de Bolzano–Weierstrass \ref{ThoBWFTXAZNH} a l'importante conséq
 \end{proposition}
 
 \begin{proof}
-    Soit \( X\) un espace métrique compact et \( f\colon X\to X\) une isométrie. Le fait que \( f\) soit injective est obligatoire (sinon il y a des images dont la distance est nulle). Il faut montrer que \( f\) est surjective.
+    Soient \( X\) un espace métrique compact et \( f\colon X\to X\) une isométrie. Le fait que \( f\) soit injective est obligatoire (sinon il y a des images dont la distance est nulle). Il faut montrer que \( f\) est surjective.
 
     Soit \( x\in X\) hors de \( f(X)\). Le lemme \ref{LemKIcAbic} appliqué au fermé \( \{ x \}\) et au compact \( f(K)\) donne un \( r>0\) tel que
     \begin{equation}
@@ -371,7 +371,7 @@ Le théorème de Bolzano–Weierstrass \ref{ThoBWFTXAZNH} a l'importante conséq
 \end{proof}
 
 \begin{proposition} \label{PropLHWACDU}
-    Soit \( (X,d)\) un espace métrique compact et \( (u_n)\) une suite de \( X\) telle que
+    Soient \( (X,d)\) un espace métrique compact et \( (u_n)\) une suite de \( X\) telle que
     \begin{equation}
         \lim_{n\to \infty} d(u_n,u_{n+1})=0.
     \end{equation}
@@ -430,7 +430,7 @@ Le théorème de Bolzano–Weierstrass \ref{ThoBWFTXAZNH} a l'importante conséq
         \begin{equation}    \label{EqIHioHjW}
             d(u_{n},u_{n+1})<\frac{ \alpha }{ 3 }.
         \end{equation}
-        Soit \( N>N_0 \) et \( x_0\in A\). Étant donné que \( x_0\) est point d'accumulation de la suite, il existe \( n_1>N\) tel que \( d(x_0,u_{n_1})<\frac{ \alpha }{ 3 }\). Même chose dans \( B\) : nous prenons \( y_0\in B\) et un naturel \( n_2>n_1\) tel que \( d(y_0,u_{n_2})<\frac{ \alpha }{ 3 }\). Nous avons \( u_{n_1}\in A'\) et \( u_{n_2}\in B'\).
+        Soient \( N>N_0 \) et \( x_0\in A\). Étant donné que \( x_0\) est point d'accumulation de la suite, il existe \( n_1>N\) tel que \( d(x_0,u_{n_1})<\frac{ \alpha }{ 3 }\). Même chose dans \( B\) : nous prenons \( y_0\in B\) et un naturel \( n_2>n_1\) tel que \( d(y_0,u_{n_2})<\frac{ \alpha }{ 3 }\). Nous avons \( u_{n_1}\in A'\) et \( u_{n_2}\in B'\).
 
         Soit \( n_0\) le plus petit naturel supérieur à \( n_1\) tel que \( u_{n_0}\notin A'\). Cela existe parce que \( u_{n_2}\in B'\) et \( B'\cap A'=\emptyset\), mais \( n_0\) n'est pas \( n_2\) lui-même parce que \( d(A',B')\geq \frac{ \alpha }{ 3 }\) alors que nous considérons \( n_0,n_1,n_2>N_0\) et donc pour tous les \( i\) entre \( n_1\) et \( n_2\) (compris), \( d(u_i,u_{i+1})<\frac{ \alpha }{ 3 }\). Notons qu'ici le strict dans la condition \eqref{EqIHioHjW} est important. Nous avons donc \(N_0<n_1<n_0<n_2\).
 
@@ -647,7 +647,7 @@ Nous allons nous limiter au cas de \( \eR\), mais je crois que ça se générali
 \index{théorème!Baire}
 
 \begin{proof}
-    Soit \( a\in S\) et \( \epsilon>0\). Nous allons trouver un élément dans \( B(a,\epsilon)\) qui n'est pas dans \( S\). Nous commençons par choisir \( x_1\in B(a,\epsilon)\) et \( r_1<\frac{ \epsilon }{2}\) tel que
+    Soient \( a\in S\) et \( \epsilon>0\). Nous allons trouver un élément dans \( B(a,\epsilon)\) qui n'est pas dans \( S\). Nous commençons par choisir \( x_1\in B(a,\epsilon)\) et \( r_1<\frac{ \epsilon }{2}\) tel que
     \begin{equation}
         B(x_1,r_1)\cap A_1=\emptyset.
     \end{equation}
@@ -710,7 +710,7 @@ Le lemme suivant justifie le vocabulaire des définitions \ref{DefZVuBbqp}.
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{definition}
-  Soit $A \subset \eR^n$ et $x \in \eR^n$. Le point $x$ est \defe{intérieur}{intérieur} à $A$ s'il existe une boule autour de $x$ complètement contenue dans $A$. L'ensemble des points intérieurs à $A$ est noté $\Int A$ ou $\mathring A$, de sorte qu'on a précisément
+  Soient $A \subset \eR^n$ et $x \in \eR^n$. Le point $x$ est \defe{intérieur}{intérieur} à $A$ s'il existe une boule autour de $x$ complètement contenue dans $A$. L'ensemble des points intérieurs à $A$ est noté $\Int A$ ou $\mathring A$, de sorte qu'on a précisément
   \begin{equation*}
     x \in \Int A \iffdefn  \exists \epsilon > 0 \tq
     B(x,\epsilon) \subset A.
@@ -736,7 +736,7 @@ Pour $A \subset \eR^n$, nous avons
 \end{definition}
 
 \begin{lemma}[Caractérisation équivalente de la frontière]      \label{LEMooEUYEooYcUfKr}
-    Soit un espace topologique \( X\) et une partie \( S\subset X\). Un point \( x\in X\) est dans \( \partial S\) si et seulement si tout voisinage de \( x\) contient un point de \( S\) et un point de \( S^c\).
+    Soient \( X\) un espace topologique et \( S\subset X\). Un point \( x\in X\) est dans \( \partial S\) si et seulement si tout voisinage de \( x\) contient un point de \( S\) et un point de \( S^c\).
 \end{lemma}
 
 \begin{proof}
@@ -888,7 +888,7 @@ Le théorème de Bolzano-Weierstrass \ref{ThoBWFTXAZNH} dit que dans le cas mét
 La surjection et l'injection sont des propriétés bien différentes qu'il convient de prouver séparément. De plus une même «formule» peut définir une application injective, surjective, bijective ou non selon le domains sur laquelle nous la considérons.
 
 \begin{definition}      \label{DEFooTRGYooRxORpY}
-    Soit une bijection \( f\colon A\to B\). L'\defe{application réciproque}{application réciproque} de \( f\) est la fonction
+    Soit \( f\colon A\to B\) une bijection. L'\defe{application réciproque}{application réciproque} de \( f\) est la fonction
     \begin{equation}
         \begin{aligned}
             f^{-1}\colon B&\to A \\
@@ -952,7 +952,7 @@ Les principaux espaces topologiques construit avec des semi-normes seront les es
     qui donne le résultat demandé en posant \( h=y-x\).
 \end{proof}
 
-Soit une famille \( (p_i)_{i\in I}\) de semi-normes sur \( E\). Nous construisons alors une topologie sur \( E\) de la façon suivante.
+Soit \( (p_i)_{i\in I}\) une famille de semi-normes sur \( E\). Nous construisons alors une topologie sur \( E\) de la façon suivante.
 
 \begin{definition}[Topologie et semi-normes\cite{SOdaAdx,MUbDonp}]
     Pour tout \( J\) fini dans \( I\) nous définissons les \defe{boules ouvertes}{boule!avec semi-normes}
@@ -979,7 +979,7 @@ Soit une famille \( (p_i)_{i\in I}\) de semi-normes sur \( E\). Nous construison
 
 La proposition suivante est un vulgaire plagiat de la proposition \ref{PropQZRNpMn}.
 \begin{proposition} \label{PropNGjQnqF}
-    Soit une application \( f\colon \eR\to (E,p_i)_{i\in I}\). Nous avons équivalence entre
+    Soit \( f\colon \eR\to (E,p_i)_{i\in I}\) une application. Nous avons équivalence entre
     \begin{enumerate}
         \item   \label{ItemHNxGMpCi}
             la fonction \( f\) est continue en \( t_0\in \eR\),
@@ -996,7 +996,7 @@ La proposition suivante est un vulgaire plagiat de la proposition \ref{PropQZRNp
 \begin{proof}
     L'équivalence \ref{ItemHNxGMpCi} \( \Leftrightarrow\) \ref{ItemHNxGMpCii} est la définition \ref{DefOLNtrxB}.
 
-    Prouvons \ref{ItemHNxGMpCii} \( \Rightarrow\) \ref{ItemHNxGMpCiii}. Soit \( i\in I\) et \( \epsilon>0\) et considérons la boule \( B_i\big( f(t_0),\epsilon \big)\), qui est un ouvert de \( E\) contenant \( f(t_0)\). Il existe donc un ouvert \( V\) autour de \( t_0\) tel que \( f(V)\subset B_i\big( f(t_0),\epsilon \big)\). En particulier \( V\) contient une boule \( B(t_0,\delta)\) et nous avons
+    Prouvons \ref{ItemHNxGMpCii} \( \Rightarrow\) \ref{ItemHNxGMpCiii}. Soient \( i\in I\) et \( \epsilon>0\). Considérons la boule \( B_i\big( f(t_0),\epsilon \big)\), qui est un ouvert de \( E\) contenant \( f(t_0)\). Il existe donc un ouvert \( V\) autour de \( t_0\) tel que \( f(V)\subset B_i\big( f(t_0),\epsilon \big)\). En particulier \( V\) contient une boule \( B(t_0,\delta)\) et nous avons
     \begin{equation}
         f\big( B(t_0,\delta) \big)\subset f(V)\subset B_i\big( f(t_0),\epsilon \big).
     \end{equation}
@@ -1042,7 +1042,7 @@ Notons que cette écart est invariant par translation au sens où pour tout \( x
             &\leq \epsilon.
         \end{align}
     \end{subequations}
-    Montrons à présent que \( \mO\) est \( d\)-ouverte. Si \( a\in\mO\), il existe \( k\) et \( r\) tels que \( B_k(a,r)\subset\mO\). Soit \( x\in B_k(a,r)\) et montrons que si \( \epsilon\) est suffisamment petit, la \( d\)-boule \( B(x,\epsilon)\) est inclue à \( B_k(a,r)\). Pour cela prenons \( y\in B(x,\epsilon)\); nous avons
+    Montrons à présent que \( \mO\) est \( d\)-ouverte. Si \( a\in\mO\), il existe \( k\) et \( r\) tels que \( B_k(a,r)\subset\mO\). Soit \( x\in B_k(a,r)\). Montrons que si \( \epsilon\) est suffisamment petit, la \( d\)-boule \( B(x,\epsilon)\) est inclue à \( B_k(a,r)\). Pour cela prenons \( y\in B(x,\epsilon)\); nous avons
     \begin{equation}
         \big| p_k(a-x)-p_k(a-y) \big|\leq d(x,y)\leq \epsilon.
     \end{equation}
@@ -1058,7 +1058,7 @@ Notons que cette écart est invariant par translation au sens où pour tout \( x
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{definition}  \label{DefHUelCDD}
-    Soit \( F\), un espace métrique et \( E\) un espace topologique vectoriel. Une topologie possible\footnote{C'est, dans l'idée, celle qui sera choisie pour les espaces de distributions, voir la définition \ref{DefASmjVaT}.} sur l'espace des applications linéaires \( \aL(E,F)\) est la \defe{topologie \( *\)-faible}{topologie!$*$-faible} qui est la topologie des semi-normes
+    Soient \( F\) un espace métrique et \( E\) un espace topologique vectoriel. Une topologie possible\footnote{C'est, dans l'idée, celle qui sera choisie pour les espaces de distributions, voir la définition \ref{DefASmjVaT}.} sur l'espace des applications linéaires \( \aL(E,F)\) est la \defe{topologie \( *\)-faible}{topologie!$*$-faible} qui est la topologie des semi-normes
     \begin{equation}
         p_v(T)=\| T(v) \|_F.
     \end{equation}
@@ -1067,7 +1067,7 @@ C'est une famille de semi-normes indicées par les éléments de \( E\). Si \( E
 
 La proposition suivante indique qu'elle est un peu la topologie de la convergence ponctuelle.
 \begin{proposition}
-    Soit \( E\) un espace muni de la topologie des semi-normes \( \{ p_i \}_{i\in I}\) et \( F\) un espace métrique. Soit une suite \( (T_n)\) dans \( \aL(E,F)\) et \( T\in \aL(E,F)\). Nous avons \( T_n\stackrel{*}{\longrightarrow}T\) si et seulement si \( T_n(v)\stackrel{F}{\longrightarrow}T(v)\) pour tout \( v\in E\).
+    Soient \( E\) un espace muni de la topologie des semi-normes \( \{ p_i \}_{i\in I}\) et \( F\) un espace métrique. Soient une suite \( (T_n)\) dans \( \aL(E,F)\) et \( T\in \aL(E,F)\). Nous avons \( T_n\stackrel{*}{\longrightarrow}T\) si et seulement si \( T_n(v)\stackrel{F}{\longrightarrow}T(v)\) pour tout \( v\in E\).
 \end{proposition}
 
 \begin{proof}
@@ -1088,11 +1088,11 @@ La proposition suivante indique qu'elle est un peu la topologie de la convergenc
 
 Nous revenons à nos histoires de limites de la définition \ref{DefXSnbhZX}.
 \begin{proposition}[Unicité de la limite dans un dual topologique] \label{PropRBCiHbz}
-    Soit \( E\) un espace métrique et \( E'\) son dual topologique muni de sa topologie de la définition \ref{DefHUelCDD}. Il y a unicité de l'élément de \( E'\) vers lequel une fonction \( u\colon \eR\to E' \) peut converger.
+    Soient \( E\) un espace métrique et \( E'\) son dual topologique muni de sa topologie de la définition \ref{DefHUelCDD}. Il y a unicité de l'élément de \( E'\) vers lequel une fonction \( u\colon \eR\to E' \) peut converger.
 \end{proposition}
 
 \begin{proof}
-    Soit \( T\) un élément vers lequel \( u_t\) converge lorsque \( t\to t_0\). Soit \( \epsilon>0\) et \( x\in E\). La boule \( B_x(T,\epsilon)\) de \( E'\) subordonnée à la norme \( p_x\) et centrée en \( T\) est un ouvert de \( E'\). Étant donné que \( u\) converge vers \( T\) il existe \( \delta>0\) tel que \( u_t\in B_x(T,\epsilon)\) dès que \( | t-t_0 |\leq \delta\). Nous avons donc, pour tout \( x\in E\), la limite (dans \( \eR\)) :
+    Soit \( T\) un élément vers lequel \( u_t\) converge lorsque \( t\to t_0\). Soient \( \epsilon>0\) et \( x\in E\). La boule \( B_x(T,\epsilon)\) de \( E'\) subordonnée à la norme \( p_x\) et centrée en \( T\) est un ouvert de \( E'\). Étant donné que \( u\) converge vers \( T\) il existe \( \delta>0\) tel que \( u_t\in B_x(T,\epsilon)\) dès que \( | t-t_0 |\leq \delta\). Nous avons donc, pour tout \( x\in E\), la limite (dans \( \eR\)) :
     \begin{equation}
         \lim_{t\to t_0} u_t(x)=T(x).
     \end{equation}
@@ -1106,7 +1106,7 @@ Nous revenons à nos histoires de limites de la définition \ref{DefXSnbhZX}.
 \end{proof}
 
 \begin{proposition} \label{PropVKSNflB}
-    Soit une fonction continue \( u\colon \eR\to E'\). Alors
+    Soit \( u\colon \eR\to E'\) une fonction continue. Alors
     \begin{enumerate}
         \item   \label{ItemLSJjfZdi}
             pour tout \( x\in E\) la fonction \( t\mapsto u_t(x)\) est continue,

--- a/tex/frido/61_representations.tex
+++ b/tex/frido/61_representations.tex
@@ -421,7 +421,7 @@ Note qu'il n'est pas possible d'inverser deux lignes à l'aide de transvections 
 \end{proof}
 
 \begin{proposition}[\cite{ooUWTWooPKySTQ}]      \label{PropooFDNRooWFfUDd}
-    Soit \( n\geq 2\) et un corps commutatif \( \eK\).
+    Soient \( n\geq 2\) et \( \eK\) un corps commutatif.
     \begin{enumerate}
         \item
             Si \( A\in \GL(n,\eK)\), il existe des transvections \( U_1,\ldots, U_r\), \( V_1,\ldots, V_s\) telles que
@@ -515,7 +515,7 @@ Note qu'il n'est pas possible d'inverser deux lignes à l'aide de transvections 
 \end{proof}
 
 \begin{proposition}[\cite{LoFdlw}]
-    Soit \( n\geq 3\) et \( \eK\) un corps de caractéristique différente de \( 2\). Alors
+    Soient \( n\geq 3\) et \( \eK\) un corps de caractéristique différente de \( 2\). Alors
     \begin{enumerate}
         \item
             le groupe dérivé de \( D(\GL(n,\eK))\) est \(\SL(n,\eK)\);  \index{groupe!dérivé!de \( \GL(n,\eK)\)}
@@ -549,7 +549,7 @@ La preuve utilise le fait que les transvections engendrent \( \SL(n,\eK)\) et qu
 \end{lemma}
 
 \begin{proof}
-    Soit \( A\), une matrice unitaire et \( Q\) une matrice unitaire qui diagonalise \( A\). Étant donné que les valeurs propres arrivent par paires complexes conjuguées,
+    Soient \( A\), une matrice unitaire et \( Q\) une matrice unitaire qui diagonalise \( A\). Étant donné que les valeurs propres arrivent par paires complexes conjuguées,
     \begin{equation}
         QAQ^{-1}=\begin{pmatrix}
             e^{i\theta_1}    &       &       &       &   \\  
@@ -571,7 +571,7 @@ La preuve utilise le fait que les transvections engendrent \( \SL(n,\eK)\) et qu
 \end{theorem}
 
 \begin{proof}
-    Soit \( A\) une matrice normale, et \( U\) une matrice unitaire qui diagonalise \( A\). Nous considérons \( U(t)\), un chemin qui joint \( \mtu\) à \( U\) dans \( \gU(n)\). Pour chaque \( t\), la matrice
+    Soient \( A\) une matrice normale et \( U\) une matrice unitaire qui diagonalise \( A\). Nous considérons \( U(t)\), un chemin qui joint \( \mtu\) à \( U\) dans \( \gU(n)\). Pour chaque \( t\), la matrice
     \begin{equation}
         A(t)=U(t)^{-1} AU(t)
     \end{equation}
@@ -606,7 +606,7 @@ La preuve utilise le fait que les transvections engendrent \( \SL(n,\eK)\) et qu
 \end{proposition}
 
 \begin{proof}
-    Soit \( A\in\GL(n,\eC)\) et sa décomposition \eqref{EQooKSQVooIpkdIE}. Comme fait précédemment, chacune des transvections peut être reliée à \( \mtu\) par un chemin continu dans \( \SL(n,\eC)\). En ce qui concerne le facteur de translation,  nous ne pouvons pas simplement prendre le chemin donné par \( t\mapsto D_n\big( t\det(A) \big)\) parce que le résultat n'est pas inversible en \( t=0\).
+    Soient \( A\in\GL(n,\eC)\) et sa décomposition \eqref{EQooKSQVooIpkdIE}. Comme fait précédemment, chacune des transvections peut être reliée à \( \mtu\) par un chemin continu dans \( \SL(n,\eC)\). En ce qui concerne le facteur de translation,  nous ne pouvons pas simplement prendre le chemin donné par \( t\mapsto D_n\big( t\det(A) \big)\) parce que le résultat n'est pas inversible en \( t=0\).
 
     Vu que \( C^*\) il existe une application continue \( \alpha\colon \mathopen[ 0 , 1 \mathclose]\to \eC^*\) telle que \( \alpha(0)=\det(A)\in \eC^*\) et \( \alpha(1)=1\). Il suffit alors de prendre \( D_n\big( \alpha(t) \big)\) et nous avons un chemin continu de \( A\) vers \( \mtu\) restant dans \( \GL(n,\eC)\).
 \end{proof}

--- a/tex/frido/64_analyseR.tex
+++ b/tex/frido/64_analyseR.tex
@@ -41,7 +41,7 @@ Un intervalle peut n'être ni ouvert ni fermé; par exemple \( \mathopen] 4 , 8 
 \end{definition}
 
 \begin{definition}[Fonction croissante, décroissante et monotone]
-    Soit une fonction \( f\colon \eR\to \eR\) et un intervalle \( I\subset \eR\).
+    Soit \( f\colon \eR\to \eR\) une fonction définie sur un intervalle \( I\subset \eR\).
     \begin{enumerate}
         \item
             Le fonction \( f\) est \defe{croissante}{fonction!croissante} sur \( I\) si pour tout \( x<y\) dans \( I\) nous avons \( f(x)\leq f(y)\). Elle est \emph{strictement} croissante si \( f(x)<f(y)\) dès que \( x<y\).
@@ -185,7 +185,7 @@ Nous disons que la fonction $x\mapsto f(x)$ est \defe{continue en $a$}{continue}
 
 
 \begin{definition}		\label{DefFonctContinueRR}
-	Soit une fonction $f\colon D\to \eR$ et un point $a$ dans $D$. Nous disons que $f$ est \defe{continue}{continue!fonction réelle} lorsque $f$ possède une limite en $a$ et $\lim_{x\to a} f(x)=f(a)$.
+	Soient $f\colon D\to \eR$ une fonction et $a$ un point dans $D$. Nous disons que $f$ est \defe{continue}{continue!fonction réelle} lorsque $f$ possède une limite en $a$ et $\lim_{x\to a} f(x)=f(a)$.
 \end{definition}
 En remplaçant $\ell$ par $f(a)$ dans la définition de la limite, nous exprimons la continuité de $f$ en $a$ par la façon suivante. Pour tout $\varepsilon>0$, il existe un $\delta>0$ tel que $\forall x\in D$,
 \begin{equation}
@@ -377,7 +377,7 @@ L'image d'un intervalle par une fonction continue est un intervalle.
 \end{corollary}
 
 \begin{proof}
-Soit \( I\) un intervalle et \( \alpha<\beta\in f(I)\) et \( \gamma\in\mathopen] \alpha , \beta \mathclose[\). Nous considérons \(a,b\in I\) tels que \( \alpha=f(a)\) et \( \beta=f(b)\). Par le théorème des valeurs intermédiaires\ref{ThoValInter}, il existe \( t\in\mathopen] a , b \mathclose[\) tel que \( f(t)=\gamma\). Par conséquent \( \gamma\in f(I)\).
+Soient \( I\) un intervalle, \( \alpha<\beta\in f(I)\) et \( \gamma\in\mathopen] \alpha , \beta \mathclose[\). Nous considérons \(a,b\in I\) tels que \( \alpha=f(a)\) et \( \beta=f(b)\). Par le théorème des valeurs intermédiaires\ref{ThoValInter}, il existe \( t\in\mathopen] a , b \mathclose[\) tel que \( f(t)=\gamma\). Par conséquent \( \gamma\in f(I)\).
 \end{proof}
 
 \begin{corollaryDef}[Existence de la racine carrée]
@@ -743,7 +743,7 @@ Notons toutefois que l'inverse de cette proposition n'est pas vraie : la fonctio
 \end{proposition}
 
 \begin{proof}
-    Soit \( x_0\) fixé et prouvons que \( d\) est continue en \( x_0\). Nous notons \( y_0\) la valeur de \( y\) qui réalise le maximum (par le théorème \ref{ThoMKKooAbHaro} et le fait que les fonctions projection soient continues, lemme \ref{LEMooHAODooYSPmvH}). Soit aussi \( \epsilon>0\) tellement fixé que même avec un tourne vis hydraulique, il ne bougerait pas. Nous considérons \( \delta\) tel que si \( \| (x,y)-(x_0,y_0) \|\leq \delta\) alors \( \| f(x,y)-f(x_0,y_0) \|<\epsilon\).
+    Soit \( x_0\) fixé. Prouvons que \( d\) est continue en \( x_0\). Nous notons \( y_0\) la valeur de \( y\) qui réalise le maximum (par le théorème \ref{ThoMKKooAbHaro} et le fait que les fonctions projection soient continues, lemme \ref{LEMooHAODooYSPmvH}). Soit aussi \( \epsilon>0\) tellement fixé que même avec un tourne vis hydraulique, il ne bougerait pas. Nous considérons \( \delta\) tel que si \( \| (x,y)-(x_0,y_0) \|\leq \delta\) alors \( \| f(x,y)-f(x_0,y_0) \|<\epsilon\).
 
     Si \( | x-x_0 |<\delta\) alors pour \( y\) assez proche de \( y_0\) nous avons \( \| (x,y)-(x_0,y_0) \|\leq \delta\), et donc \( \| f(x,y)-f(x_0,y_0) \|\leq \epsilon \). Cela montre qu'il existe \( \delta\) tel que \( | x-x_0 |\leq \delta\) implique \( d(x)\geq d(x_0)-\epsilon\).
 
@@ -873,7 +873,7 @@ Nous considérons la question suivante : étant donné une fonction \( f\) défi
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{proposition}
-    Soit une bijection \( f\colon I\to J\) et \( f^{-1}\colon J\to I\) sa réciproque. Alors pour tout \( x_0\in I\) nous avons
+    Soient \( f\colon I\to J\) une bijection et \( f^{-1}\colon J\to I\) sa réciproque. Alors pour tout \( x_0\in I\) nous avons
     \begin{equation}    \label{EqHQRooNmLYbF}
         f^{-1}\big( f(x_0) \big)=x_0
     \end{equation}
@@ -886,7 +886,7 @@ Nous considérons la question suivante : étant donné une fonction \( f\) défi
 \begin{proof}
     Nous prouvons la relation \eqref{EqHQRooNmLYbF} et nous laissons \eqref{EqIYTooQPvZDr} comme exercice au lecteur.
 
-    Soit \( x_0\in I\), et posons \( y_0=f(x_0)\). La définition de l'application réciproque est que pour \( y\in J\), \( f^{-1}(y)\) est l'unique élément \( x\) de \( I\) tel que \( f(x)=y\). Donc \( f^{-1}(y_0)\) est l'unique élément de \( I\) dont l'image est \( y_0\). C'est donc \( x_0\) et nous avons \( f^{-1}(y_0)=x_0\), c'est à dire
+    Soit \( x_0\in I\). Posons \( y_0=f(x_0)\). La définition de l'application réciproque est que pour \( y\in J\), \( f^{-1}(y)\) est l'unique élément \( x\) de \( I\) tel que \( f(x)=y\). Donc \( f^{-1}(y_0)\) est l'unique élément de \( I\) dont l'image est \( y_0\). C'est donc \( x_0\) et nous avons \( f^{-1}(y_0)=x_0\), c'est à dire
     \begin{equation}
         f^{-1}\big( f(x_0) \big)=x_0.
     \end{equation}
@@ -954,7 +954,7 @@ Nous considérons la question suivante : étant donné une fonction \( f\) défi
 \end{proof}
 
 \begin{proposition}[\cite{XGIooNMtKqx}] \label{PropMRBooXnnDLq}
-    Soit \( f\colon I\to J=f(I)\) une fonction bijective, continue et dérivable\footnote{Pour rappel, une fonction dérivable est toujours continue; l'hypothèse de continuité n'est pas nécessaire}. Soit \( x_0\in I\) et \( y_0=f(x_0)\). Si \( f'(x_0)\neq 0\) alors la fonction réciproque \( f^{-1}\) est dérivable en \( y_0\) et sa dérivée est donnée par
+    Soit \( f\colon I\to J=f(I)\) une fonction bijective, continue et dérivable\footnote{Pour rappel, une fonction dérivable est toujours continue; l'hypothèse de continuité n'est pas nécessaire}. Soient \( x_0\in I\) et \( y_0=f(x_0)\). Si \( f'(x_0)\neq 0\) alors la fonction réciproque \( f^{-1}\) est dérivable en \( y_0\) et sa dérivée est donnée par
     \begin{equation}    
         (f^{-1})'(y_0)=\frac{1}{ f'(x_0) }.
     \end{equation}

--- a/tex/frido/73_Integration.tex
+++ b/tex/frido/73_Integration.tex
@@ -309,7 +309,7 @@ En ce qui concerne les fonctions dans \( \eR^n\), il y a les  propositions \ref{
 \end{definition}
 
 \begin{theorem}     \label{ThoDerSousIntegrale}
-    Soit \( A\) un ouvert de \( \eR\) et \( \Omega\), un espace mesuré. Soit une fonction \( f\colon A\times \Omega\to \eR\) et
+    Soient \( A\) un ouvert de \( \eR\) et \( \Omega\) un espace mesuré. Soient une fonction \( f\colon A\times \Omega\to \eR\) et
     \begin{equation}
         F(x)=\int_{\Omega}f(x,\omega)d\omega.
     \end{equation}

--- a/tex/frido/75_series_fonctions.tex
+++ b/tex/frido/75_series_fonctions.tex
@@ -113,7 +113,7 @@ Dans cette partie, nous désignons par \( \Omega\) un ouvert de \( \eC\).
 \end{proof}
 
 \begin{normaltext}      \label{NORMooMKNDooBeoGRN}
-    Soit une fonction \( f\colon \eC\to \eC\) et l'isomorphisme canonique \( \varphi\colon \eC\to \eR^2\). La fonction \( f\) définit une la fonction
+    Soient une fonction \( f\colon \eC\to \eC\) et l'isomorphisme canonique \( \varphi\colon \eC\to \eR^2\). La fonction \( f\) définit une la fonction
     \begin{equation}
         F=\varphi^{-1} \circ f\circ \varphi\colon \eR^2\to \eR^2.
     \end{equation}
@@ -282,7 +282,7 @@ Il est bon de se rappeler des convergences absolues (définition \ref{DefVFUIXwU
 \end{proposition}
 
 \begin{proof}
-    Nous posons \( u(z)=\lim_{N\to \infty} \sum_{n=0}^N u_n(z)\), et nous vérifions que la fonction ainsi définie sur \( \Omega\) est continue. Soit \( z\in \Omega\) et prouvons la continuité de \( u\) au point \( z\). Pour tout \( z'\) dans un voisinage de \( z\) nous avons 
+    Nous posons \( u(z)=\lim_{N\to \infty} \sum_{n=0}^N u_n(z)\), et nous vérifions que la fonction ainsi définie sur \( \Omega\) est continue. Soit \( z\in \Omega\). Prouvons la continuité de \( u\) au point \( z\). Pour tout \( z'\) dans un voisinage de \( z\) nous avons 
     \begin{subequations}
         \begin{align}
             \big| u(z)-u(z') \big|&=\left| \sum_{n=0}^{N}u_n(z)-\sum_{n=0}^{N}u_n(z')+\sum_{n=N+1}^{\infty}u_n(z)-\sum_{n=N+1}^{\infty}u_n(z') \right| \\
@@ -319,7 +319,7 @@ Le corollaire suivant permet de considérer des séries de fonctions indexées p
 \end{corollary}
 
 \begin{proof}
-    Soit \( I\) dénombrable et considérons une famille de fonctions continues \( (f_n)_{n\in I}\) telles que la famille \( (\| f_i \|_{\infty})_{i\in I}\) soit sommable. Le proposition \ref{PropoWHdjw} nous permet d'utiliser une bijection entre \( I\) et \( \eN\). Le théorème \ref{PropUEMoNF} s'applique alors.
+    Soit \( I\) dénombrable. Considérons une famille de fonctions continues \( (f_n)_{n\in I}\) telles que la famille \( (\| f_i \|_{\infty})_{i\in I}\) soit sommable. Le proposition \ref{PropoWHdjw} nous permet d'utiliser une bijection entre \( I\) et \( \eN\). Le théorème \ref{PropUEMoNF} s'applique alors.
 \end{proof}
 
 \begin{theorem}[Critère de Weierstrass]\index{critère!Weierstrass!série de fonctions}		\label{ThoCritWeierstrass}
@@ -443,7 +443,7 @@ Le théorème suivant est une paraphrase du théorème de la convergence dominé
 \end{lemma}
 
 \begin{theorem}[\cite{DHdwZRZ}] \label{ThoLDpRmXQ}
-    Soit \( E\) et \( F\), deux espaces vectoriels normés, \( \Omega\) un ouvert connexe par arcs de \( E\). Soit \( (u_n)\) une suite de fonctions \( u_n\colon \Omega\to F\) telle que
+    Soient \( E\) et \( F\) deux espaces vectoriels normés, \( \Omega\) un ouvert connexe par arcs de \( E\). Soit \( (u_n)\) une suite de fonctions \( u_n\colon \Omega\to F\) telle que
     \begin{enumerate}
         \item
             pour tout \( n\), la fonction \( u_n\) est de classe \( C^1\) sur \( \Omega\),
@@ -461,7 +461,7 @@ Le théorème suivant est une paraphrase du théorème de la convergence dominé
 \begin{proof}
     Pour chaque \( n\), la fonction \( du_n\colon \Omega\to \aL(E,F)\) est une fonction continue parce que \( u_n\) est de classe \( C^1\). La série convergeant normalement, la fonction \( \sum_{n=0}^{\infty}du_n\) est également continue par la proposition \ref{PropOMBbwst}. La difficulté de ce théorème est donc de prouver que cela est bien la différentielle de la fonction \( \sum_nu_n\).
 
-    Soit \( a,x\in \Omega\) et \( \gamma\colon \mathopen[ 0 , 1 \mathclose]\to \Omega\) un chemin joignant \( a\) à \( x\). Nous considérons ce chemin en coordonnées normales et nous notons \( l\) sa longueur. Par définition \eqref{EqEFIZyEe},
+    Soient \( a,x\in \Omega\) et \( \gamma\colon \mathopen[ 0 , 1 \mathclose]\to \Omega\) un chemin joignant \( a\) à \( x\). Nous considérons ce chemin en coordonnées normales et nous notons \( l\) sa longueur. Par définition \eqref{EqEFIZyEe},
     \begin{equation}
         \clubsuit=\int_{\gamma}\sum_{n=0}^{\infty}du_n=\int_0^l\sum_n(du_n)_{\gamma(t)}\big( \gamma'(t) \big)dt
     \end{equation}
@@ -1685,7 +1685,7 @@ Ce théorème prend une nouvelle force en considérant le théorème de Müntz \
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 \begin{theorem}[Nombres de Bell\cite{KXjFWKA}]  \label{ThoYFAzwSg}
-    Soit \( n\geq 1\) et \( B_n\) le nombre de partitions distinctes de l'ensemble \( \{ 1,\ldots, n \}\) avec la convention que \( B_0=0\). Alors
+    Soient \( n\geq 1\) et \( B_n\) le nombre de partitions distinctes de l'ensemble \( \{ 1,\ldots, n \}\) avec la convention que \( B_0=0\). Alors
     \begin{enumerate}
         \item
             La série entière
@@ -1715,7 +1715,7 @@ Ce théorème prend une nouvelle force en considérant le théorème de Müntz \
 \begin{proof}
     \begin{enumerate}
         \item
-            Soit \( n\geq 1\) et \( 0\leq k\leq n\). Nous notons \( E_k\) l'ensemble des partitions de \( \{ 1,\ldots, n+1 \}\) pour lesquelles le «paquet» contenant \( n+1\) soit de cardinal \( k+1\). Calculons le cardinal de \( E_k\).
+            Soient \( n\geq 1\) et \( 0\leq k\leq n\). Nous notons \( E_k\) l'ensemble des partitions de \( \{ 1,\ldots, n+1 \}\) pour lesquelles le «paquet» contenant \( n+1\) soit de cardinal \( k+1\). Calculons le cardinal de \( E_k\).
 
             Pour construire un élément de \( E_k\), il faut d'abord prendre le nombre \( n+1\) et lui adjoindre \( k\) éléments choisis dans \( \{ 1,\ldots, n \}\), ce qui donne \( n\choose k\) possibilités. Ensuite il faut trouver une partition des \( (n+1)-(k+1)=n-k\) éléments restants, ce qui fait \( B_{n-k}\) possibilités. Donc
             \begin{equation}

--- a/tex/frido/80_Newton.tex
+++ b/tex/frido/80_Newton.tex
@@ -42,7 +42,7 @@ Sources : \cite{RasclAnaFonc}
 \end{proposition}
 
 \begin{proof}
-    Soit \( x\in X\) et la suite d'ensemble
+    Soient \( x\in X\) et $(A_n)_{n\geq 0}$ la suite d'ensembles définie par
     \begin{equation}
         A_n=\{ y\in A\tq \| x-y \|\leq 2^{-n}\}.
     \end{equation}
@@ -90,7 +90,7 @@ Sources : \cite{RasclAnaFonc}
 
     Nous montrons maintenant que \( S\) prolonge \( f\). Si \( x\in A\), alors nous avons \( \bigcap_{n\in \eN}f(A_n)=f(x)\), et donc \( S(x)=f(x)\). Cela montre du même coup que \( \| f \|\leq \| S \|\) et que par conséquent \( \| f \|=\| S \|\).
 
-    Passons à la partie sur l'unicité. Soient donc \( S\) et \( T\), deux prolongements continus de \( f\) sur \( X\). Soit \( x\in X\) et une suite \( x_n\to x\) dans \( A\). Par continuité nous avons \( T(x_n)\to T(x)\) et \( S(x_n)\to S(x)\). Étant donné que par ailleurs pour tout \( n\) nous avons \( S(x_n)=T(x_n)\), l'unicité de la limite montre que \( T(x)=S(x)\).
+    Passons à la partie sur l'unicité. Soient donc \( S\) et \( T\)  deux prolongements continus de \( f\) sur \( X\). Soient \( x\in X\) et \( x_n\to x\) une suite dans \( A\). Par continuité nous avons \( T(x_n)\to T(x)\) et \( S(x_n)\to S(x)\). Étant donné que par ailleurs pour tout \( n\) nous avons \( S(x_n)=T(x_n)\), l'unicité de la limite montre que \( T(x)=S(x)\).
 \end{proof}
 
 \begin{definition}
@@ -150,7 +150,7 @@ Dans la même veine que la proposition \ref{PropTTiRgAq} nous avons ce résultat
     \begin{equation}        \label{EqFRYqON}
         \omega_{\tilde u}(h)\geq \omega_u(h).
     \end{equation}
-    Soit \( h>0\) et \( \epsilon>0\); soit aussi \( x,y\in E\) tels que \( d(x,y)<h\). Nous prenons des suites \( (a_n)\to x\) et \( (y_n)\to y\) tout en choisissant \( n\) assez grand pour avoir \( d_E(a_n,b_n)<h\). Nous avons
+    Soient \( h>0\) et \( \epsilon>0\); soient aussi \( x,y\in E\) tels que \( d(x,y)<h\). Nous prenons des suites \( (a_n)\to x\) et \( (y_n)\to y\) tout en choisissant \( n\) assez grand pour avoir \( d_E(a_n,b_n)<h\). Nous avons
     \begin{equation}
         d_F\big( \tilde u(x),\tilde u(y) \big)\leq d_F\big( \tilde u(x),u(a_n) \big)+d\big( u(a_n),u(b_n) \big)+d_F\big( u(b_n),\tilde u(y) \big).
     \end{equation}
@@ -189,7 +189,7 @@ Dans la même veine que la proposition \ref{PropTTiRgAq} nous avons ce résultat
 \index{théorème!extension d'isométrie}
 
 \begin{proof}
-    Nous commençons par prouver l'unicité. Soit \( \tilde f_1\) et \( \tilde f_2\), deux extensions de \( f\) et \( x\in M\). Si \( (a_n)\) est une suite dans \( A\) convergeant vers \( x\) (possible parce que \( A\) est dense dans \( M\)), alors nous avons
+    Nous commençons par prouver l'unicité. Soient \( \tilde f_1\) et \( \tilde f_2\) deux extensions de \( f\) et \( x\in M\). Si \( (a_n)\) est une suite dans \( A\) convergeant vers \( x\) (possible parce que \( A\) est dense dans \( M\)), alors nous avons
     \begin{equation}
         \tilde f_1(a_n)=\tilde f_2(a_n)
     \end{equation}
@@ -199,7 +199,7 @@ Dans la même veine que la proposition \ref{PropTTiRgAq} nous avons ce résultat
     
     \begin{subproof}
     \item[Construction de \( \tilde f\)]
-    Soit \( x\in M\) et \( (a_n)\) une suite dans \( A\) qui converge vers \( x\). Nous définissons
+    Soient \( x\in M\) et \( (a_n)\) une suite dans \( A\) qui converge vers \( x\). Nous définissons
     \begin{equation}    \label{EqHEembqy}
         \tilde f(x)=\lim_{k\to \infty} f(a_k).
     \end{equation}
@@ -234,7 +234,7 @@ Dans la même veine que la proposition \ref{PropTTiRgAq} nous avons ce résultat
 
     \item[Bijection (l'autre sens)]
 
-        Nous supposons que \( \overline{ f(A) }=\tilde M\) et nous devons prouver que \( \tilde f\) est surjective. Soit \( x\in \tilde M\) et \( f(a_n)\) une suite dans \( f(A)\) qui converge vers \( x\); une telle suite existe parce que \( f(A)\) est dense dans \( \tilde M\). Cette suite est de Cauchy dans \( \tilde M\) parce que dans un espace métrique, une suite convergente est de Cauchy. La suite \( (a_n)\) est elle-même également de Cauchy parce que
+        Nous supposons que \( \overline{ f(A) }=\tilde M\) et nous devons prouver que \( \tilde f\) est surjective. Soient \( x\in \tilde M\) et \( f(a_n)\) une suite dans \( f(A)\) qui converge vers \( x\); une telle suite existe parce que \( f(A)\) est dense dans \( \tilde M\). Cette suite est de Cauchy dans \( \tilde M\) parce que dans un espace métrique, une suite convergente est de Cauchy. La suite \( (a_n)\) est elle-même également de Cauchy parce que
         \begin{equation}
             d(a_n,a_m)=d\big( f(a_n),f(a_m) \big).
         \end{equation}

--- a/tex/frido/82_analyse_fonctionnelle.tex
+++ b/tex/frido/82_analyse_fonctionnelle.tex
@@ -440,7 +440,7 @@ Il est intuitivement clair que ce qui peut arriver à une fonction en un seul po
 \index{inégalité!Jensen!version intégrale}
 
 \begin{proof}
-    Soit \( a\in \eR\) et le nombre \( c_a\) donné par la proposition \ref{PropNIBooSbXIKO} : pour tout \( \omega\in \Omega\) nous avons
+    Soient \( a\in \eR\) et \( c_a\) le nombre donné par la proposition \ref{PropNIBooSbXIKO} : pour tout \( \omega\in \Omega\) nous avons
     \begin{equation}    \label{EqOUMooIwknIP}
         f\big( \alpha(\omega) \big)-f(a)\geq c_a\big( \alpha(\omega)-a \big).
     \end{equation}

--- a/tex/frido/84_AnalyseComplexe.tex
+++ b/tex/frido/84_AnalyseComplexe.tex
@@ -240,7 +240,7 @@ Les équations \eqref{EqmblExI} sont les équations de \defe{Cauchy-Riemann}{Cau
 \end{proof}
 
 \begin{proposition}[\cite{Holomorphieus}]   \label{PrpopwQSbJg}
-    Soit \( \Omega\) un ouvert étoilé et \( f\) une fonction holomorphe sur \( \Omega\) sauf éventuellement en un point \( z_1\) où \( f\) est seulement continue. Alors si \( \gamma\) est un chemin fermé dans \( \Omega\), nous avons
+    Soient \( \Omega\) un ouvert étoilé et \( f\) une fonction holomorphe sur \( \Omega\) sauf éventuellement en un point \( z_1\) où \( f\) est seulement continue. Alors si \( \gamma\) est un chemin fermé dans \( \Omega\), nous avons
     \begin{equation}
         \int_{\gamma}f=0.
     \end{equation}
@@ -314,14 +314,14 @@ Le second point est en partie la proposition \ref{PropHSjJcIr}.
 \end{example}
 
 \begin{theorem}[Cauchy, version homotopique\cite{ADEyNiz}]
-    Soit \( \Omega\) un ouvert de \( \eC\) et \( f\) une fonction holomorphe sur \( \Omega\). Si \( \gamma_1\) et \( \gamma_2\) sont deux lacets homotopes de classe \( C^1\) dans \( \Omega\), alors
+    Soient \( \Omega\) un ouvert de \( \eC\) et \( f\) une fonction holomorphe sur \( \Omega\). Si \( \gamma_1\) et \( \gamma_2\) sont deux lacets homotopes de classe \( C^1\) dans \( \Omega\), alors
     \begin{equation}
         \int_{\gamma_1}f(z)dz=\int_{\gamma_2}f(z)dz.
     \end{equation}
 \end{theorem}
 
 \begin{corollary}[\cite{ADEyNiz}]   \label{CorGZXzuZR}
-    Soit \( a\in \eC\) ainsi que deux chemins \( \gamma_1\) et \( \gamma_2\) homotopes dans \( \eC\setminus\{ a \}\). Alors \( \Int(\gamma_1,a)=\Ind(\gamma_2,a)\).
+    Soient \( a\in \eC\) ainsi que deux chemins \( \gamma_1\) et \( \gamma_2\) homotopes dans \( \eC\setminus\{ a \}\). Alors \( \Int(\gamma_1,a)=\Ind(\gamma_2,a)\).
 \end{corollary}
 Il y a aussi des choses sur l'indice dans \cite{Holomorphieus}.
 
@@ -334,7 +334,7 @@ Cette sous-section veut prouver le théorème de Cauchy. Comme d'habitude, une r
 
 
 \begin{theorem}[Formule de Cauchy]    \label{ThoUHztQe}
-    Soit \( \Omega\) ouvert dans \( \eC\), \( z_0\in \Omega\) et \( f\), une fonction holomorphe sur \( \Omega\). Soit \( r>0\) tel que \( B(z_0,r)\subset \Omega\). Alors pour tout \( z\in B(z_0,r)\) nous avons
+    Soient \( \Omega\) ouvert dans \( \eC\), \( z_0\in \Omega\) et \( f\) une fonction holomorphe sur \( \Omega\). Soit \( r>0\) tel que \( B(z_0,r)\subset \Omega\). Alors pour tout \( z\in B(z_0,r)\) nous avons
     \begin{equation}    \label{EqPzUABM}
         f(z)=\frac{1}{ 2\pi i }\int_{\partial B(z_0,r)}\frac{ f(\omega) }{ \omega-z }d\omega.
     \end{equation}
@@ -343,7 +343,7 @@ Cette sous-section veut prouver le théorème de Cauchy. Comme d'habitude, une r
 \index{Cauchy!formule}
 
 \begin{proof}
-    Soit \( z\in B(z_0,r)\) et considérons la fonction
+    Soit \( z\in B(z_0,r)\). Considérons la fonction
     \begin{equation}
         g(\omega)=\begin{cases}
             \frac{ f(\omega)-f(z) }{ \omega-z }    &   \text{si } \omega\neq z\\
@@ -374,7 +374,7 @@ Cette sous-section veut prouver le théorème de Cauchy. Comme d'habitude, une r
 \end{definition}
 
 \begin{theorem}     \label{ThomcPOdd}
-    Soit \( \Omega\) ouvert dans \( \eC\) et \( f\), holomorphe sur \( \Omega\). Soient encore \( z_0\in \Omega\) et \( r_0\) tel que \( B(z_0,r_0)\subset \Omega\). Alors :
+    Soient \( \Omega\) ouvert dans \( \eC\) et \( f\) holomorphe sur \( \Omega\). Soient encore \( z_0\in \Omega\) et \( r_0\) tels que \( B(z_0,r_0)\subset \Omega\). Alors :
     \begin{enumerate}
         \item
             Sur \( B(z_0,r_0)\), la fonction \( f\) s'écrit
@@ -620,7 +620,7 @@ Pour d'autres versions du théorème de Brouwer, voir la sous-section \ref{subSe
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{proposition} \label{PropDRnYkKP}
-    Soit \( \Omega\), un ouvert de \( \eC\) et \( f\colon \Omega\to \eC\) une fonction holomorphe sur \( \Omega\setminus\{ a \}\) (\( a\in \Omega\)). Nous supposons qu'il existe \( r>0\) tel que \( f\) est bornée sur \( B(a,r)\cap\Omega\). Alors \( f\) se prolonge en une fonction holomorphe sur \( \Omega\).
+    Soient \( \Omega\) un ouvert de \( \eC\) et \( f\colon \Omega\to \eC\) une fonction holomorphe sur \( \Omega\setminus\{ a \}\) (\( a\in \Omega\)). Nous supposons qu'il existe \( r>0\) tel que \( f\) est bornée sur \( B(a,r)\cap\Omega\). Alors \( f\) se prolonge en une fonction holomorphe sur \( \Omega\).
 \end{proposition}
 Le théorème de prolongement de Riemann \ref{ThoTLQOEwW} donnera plus d'informations.
 
@@ -1063,7 +1063,7 @@ Tout ce petit monde à propos de la mesure de Radon permet également de redémo
 Nous nous proposons de lister les conditions que nous avons vues être équivalentes à l'holomorphie.
 
 \begin{theorem}
-    Soit \( \Omega\) un ouvert de \( \eC\) et \( f\colon \Omega\to \eC\) une fonction continue. Les conditions suivantes sont équivalentes.
+    Soient \( \Omega\) un ouvert de \( \eC\) et \( f\colon \Omega\to \eC\) une fonction continue. Les conditions suivantes sont équivalentes.
     \begin{enumerate}
         \item   \label{ItemOtPcTb}
             \( f\) est holomorphe.

--- a/tex/frido/85_AnalyseComplexe.tex
+++ b/tex/frido/85_AnalyseComplexe.tex
@@ -35,7 +35,7 @@
 
 Le théorème suivant compète la proposition \ref{PropDRnYkKP}.
 \begin{theorem}[Prolongement de Riemann]    \label{ThoTLQOEwW}
-    Soit \( f\colon \Omega\to \eC\) et une singularité \( Z\) de \( f\). Nous avons équivalence de 
+    Soient \( f\colon \Omega\to \eC\) et \( Z\) une singularité de \( f\). Nous avons équivalence de 
     \begin{enumerate}
         \item
             la singularité \( Z\) est effaçable;
@@ -50,11 +50,11 @@ Le théorème suivant compète la proposition \ref{PropDRnYkKP}.
 \index{théorème!prolongement de Riemann}
 
 \begin{definition}[Fonction méromorphe\cite{ooBBIEooFYzkzz}]
-    Soit un ouvert \( \mU\) de \( \eC\) et une suite de points \( \{ p_i \}\) dans \( \mU\) sans points d'accumulation (éventuellement il y a un nombre fini de \( p_i\)). Si la fonction \( f\) est holomorphe sur \( \mU\setminus\{ p_i \}\) et si chaque \( p_i\) est un point régulier ou un pôle de \( f\), alors nous disons que \( f\) est \defe{méromorphe}{méromorphe} sur \( \mU\).
+    Soient \( \mU\) un ouvert de \( \eC\) et \( \{ p_i \}\) une suite de points dans \( \mU\) sans points d'accumulation (éventuellement il y a un nombre fini de \( p_i\)). Si la fonction \( f\) est holomorphe sur \( \mU\setminus\{ p_i \}\) et si chaque \( p_i\) est un point régulier ou un pôle de \( f\), alors nous disons que \( f\) est \defe{méromorphe}{méromorphe} sur \( \mU\).
 \end{definition}
 
 \begin{proposition} \label{PropPUZTQKl}
-    Soit \( \Omega\) un ouvert de \( \eC\) et une suite de fonctions \( f_n\colon \Omega\to \eC\) telles que pour tout compact \( K\) de \( \Omega\) il existe \( N_K\geq 0\) tel que
+    Soient \( \Omega\) un ouvert de \( \eC\) et \( f_n\colon \Omega\to \eC\) une suite de fonctions telles que pour tout compact \( K\) de \( \Omega\) il existe \( N_K\geq 0\) tel que
     \begin{enumerate}
         \item
             \( f_n\) n'a pas de pôles dans \( K\) dès que \( n\geq N_K\);
@@ -1307,7 +1307,7 @@ lorsque la somme dépasse les bornes de \( \mathopen] -\pi , \pi \mathclose]\). 
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 \begin{theorem}[Montel\cite{KXjFWKA}]   \label{ThoXLyCzol}
-    Soit \( \Omega\) un ouvert de \( \eC\) et \( \mF\) une famille de fonctions holomorphes sur \( \Omega\), uniformément bornée sur tout compact de \( \Omega\). Alors de toute suite dans \( \mF\) nous pouvons extraire une sous-suite convergeant uniformément sur tout compact de \( \Omega\).
+    Soient \( \Omega\) un ouvert de \( \eC\) et \( \mF\) une famille de fonctions holomorphes sur \( \Omega\), uniformément bornée sur tout compact de \( \Omega\). Alors de toute suite dans \( \mF\) nous pouvons extraire une sous-suite convergeant uniformément sur tout compact de \( \Omega\).
 \end{theorem}
 \index{théorème!Montel}
 \index{compacité!utilisation!théorème de Montel}
@@ -1359,7 +1359,7 @@ lorsque la somme dépasse les bornes de \( \mathopen] -\pi , \pi \mathclose]\). 
 \end{proof}
 
 \begin{corollary}[\cite{KXjFWKA}]
-    Soit \( \Omega\) un ouvert connexe borné de \( \eC\) et \( a\in \Omega\). Soit \( f\) holomorphe sur \( \Omega\) telle que \( f(a)=a\) et \( | f'(a) |<1\).
+    Soient \( \Omega\) un ouvert connexe borné de \( \eC\) et \( a\in \Omega\). Soit \( f\) holomorphe sur \( \Omega\) telle que \( f(a)=a\) et \( | f'(a) |<1\).
 
     Alors de \( (f^n)\) on peut extraire une sous-suite convergeant uniformément sur tout compact de \( \Omega\) vers la fonction constante \( a\).
 \end{corollary}

--- a/tex/frido/86_Fourier.tex
+++ b/tex/frido/86_Fourier.tex
@@ -119,7 +119,7 @@ Note : ce noyau est positif. C'est important parce qu'on s'en sert dans la preuv
 
 
 \begin{theorem}[Fejèr]      \label{ThoJFqczow}
-    Soit une fonction continue et \( 2\pi\)-périodique \( f\colon \eR\to \eC\). Pour tout \( k\in \eZ\) nous notons
+    Soit \( f\colon \eR\to \eC\) une fonction continue et \( 2\pi\)-périodique. Pour tout \( k\in \eZ\) nous notons
     \begin{equation}
         \begin{aligned}
             e_k\colon \eR&\to \eC \\

--- a/tex/frido/88_distributions.tex
+++ b/tex/frido/88_distributions.tex
@@ -782,7 +782,7 @@ En effet
     \end{subequations}
     Nous allons progressivement montrer qu'en prenant \( \delta\) assez petit et \( n\) assez grand, les quantités \( | I_n-I_{\delta,n} |\), \( | I_{\delta,n}-Z_{\delta,n}  |\) et \( | Z_{\delta,n}-u(0) |\) peuvent être simultanément majorées par \( \epsilon\).
 
-    Soit \( \delta>0\) et \( \epsilon>0\); vu que \( u\in\swS(\eR)\), il existe \( M\) tel que \( \int_{| x |>M}| u |<\epsilon\). Soit \( N_1\in \eN\) tel que pour tout \( n>N_1\) nous avons \( | j_n(x) |<1\) dès que \( | x |>M\) (hypothèse \ref{ITEMooFQYXooEkUAIb}). Alors
+    Soient \( \delta>0\) et \( \epsilon>0\); vu que \( u\in\swS(\eR)\), il existe \( M\) tel que \( \int_{| x |>M}| u |<\epsilon\). Soit \( N_1\in \eN\) tel que pour tout \( n>N_1\) nous avons \( | j_n(x) |<1\) dès que \( | x |>M\) (hypothèse \ref{ITEMooFQYXooEkUAIb}). Alors
     \begin{equation}
         \int_{| x |>M}| j_n(x)u(x) |<\epsilon.
     \end{equation}
@@ -981,7 +981,7 @@ Si aucune ambigüité n'est à craindre, nous noterons \( f\) la distribution \(
 
 D'abord parlons un peu de continuité en recopiant la proposition \ref{PropVKSNflB} dans notre contexte.
 \begin{proposition}     \label{PropIPlKQBa}
-    Soit \( I\) un intervalle ouvert de \( \eR\) et une fonction continue \( u\colon I\to \swD'(\eR^d)\). Alors
+    Soient \( I\) un intervalle ouvert de \( \eR\) et \( u\colon I\to \swD'(\eR^d)\) une fonction continue. Alors
     \begin{enumerate}
         \item   \label{ItemYAhnNhBi}
             Pour tout \( \varphi\in\swD(\eR^d)\), l'application \( t\mapsto u_t(\varphi)\) est continue.
@@ -1015,7 +1015,7 @@ est de classe \( C^k\).
 \end{proposition}
 
 \begin{proof}
-    La fonction dont nous voulons prouver la continuité est une fonction \( \eR\to\eR\); il est donc loisible de se contenter de la continuité séquentielle. Soit \( t_0\in I\) et \( (t_j)\) une suite dans \( I\) convergeant vers \( t_0\). Nous posons \( U_j=T_{t_j}\) et \( \psi_j=\psi\big( t_j,. \big)\). Par hypothèse de continuité de \( (T_t)\) nous avons \( U_j\stackrel{\swD'(\Omega)}{\longrightarrow}T_{t_0}\). D'autre part le support de \( \psi\) étant compact nous avons \( \supp(\psi)\subset \mathopen[ c , d \mathclose]\times K\) où \( \mathopen[ c , d \mathclose]\subset I\) et \( K\) est compact dans \( \Omega\). Par conséquent nous avons aussi \( \supp(\psi_j)\subset K\).
+    La fonction dont nous voulons prouver la continuité est une fonction \( \eR\to\eR\); il est donc loisible de se contenter de la continuité séquentielle. Soient \( t_0\in I\) et \( (t_j)\) une suite dans \( I\) convergeant vers \( t_0\). Nous posons \( U_j=T_{t_j}\) et \( \psi_j=\psi\big( t_j,. \big)\). Par hypothèse de continuité de \( (T_t)\) nous avons \( U_j\stackrel{\swD'(\Omega)}{\longrightarrow}T_{t_0}\). D'autre part le support de \( \psi\) étant compact nous avons \( \supp(\psi)\subset \mathopen[ c , d \mathclose]\times K\) où \( \mathopen[ c , d \mathclose]\subset I\) et \( K\) est compact dans \( \Omega\). Par conséquent nous avons aussi \( \supp(\psi_j)\subset K\).
 
     Affin d'alléger les notations notons \( \tilde \psi(x)=\psi(t_0,x)\). Pour tout multiindice \( \alpha\) et pour tout \( j\) nous avons
     \begin{equation}
@@ -1128,7 +1128,7 @@ La définition de l'espace \(  C^{\infty}(I,\swS'(\Omega))\) est encore la défi
 
 D'abord parlons un peu de continuité en recopiant la proposition \ref{PropVKSNflB} dans notre contexte.
 \begin{proposition}     \label{PropBXFmvPs}
-    Soit \( I\) un intervalle ouvert de \( \eR\) et une fonction continue \( u\colon I\to \swS'(\eR^d)\). Alors
+    Soient \( I\) un intervalle ouvert de \( \eR\) et \( u\colon I\to \swS'(\eR^d)\) une fonction continue. Alors
     \begin{enumerate}
         \item   \label{ItemFTvVUEW}
             Pour tout \( \varphi\in\swS(\eR^d)\), l'application \( t\mapsto u_t(\varphi)\) est continue.
@@ -1206,7 +1206,7 @@ D'abord parlons un peu de continuité en recopiant la proposition \ref{PropVKSNf
 \end{proposition}
 
 \begin{proof}
-    Soit \( t_0\in I\) et une suite convergente vers \( t_0\) : \( t_j\to t_0\) dans \( \eR\). Vu que \( (T_t)\) est continue en \( t\), elle est en particulier séquentiellement continue et nous avons
+    Soient \( t_0\in I\) et une suite convergente vers \( t_0\) : \( t_j\to t_0\) dans \( \eR\). Vu que \( (T_t)\) est continue en \( t\), elle est en particulier séquentiellement continue et nous avons
     \begin{equation}
         T_{t_j}\stackrel{\swS'(\Omega)}{\longrightarrow}T_{t_0}.
     \end{equation}
@@ -1305,7 +1305,7 @@ Attention que la formule \eqref{EqZMDeZco} est bonne si \( \varphi\in\swS(\Omega
 \end{proposition}
 
 \begin{proof}
-    Soit \( t_0\in I\) et une suite réelle \( \epsilon_j\to 0\). Le membre de gauche de \eqref{EqSCNYYhE}, écrit en \( t_0\), donne
+    Soient \( t_0\in I\) et \( \epsilon_j\to 0\) une suite réelle. Le membre de gauche de \eqref{EqSCNYYhE}, écrit en \( t_0\), donne
     \begin{equation}    \label{BJPHzwn}
         \spadesuit=\lim_{j\to \infty} \frac{ T_{t_0+\epsilon_j}\big( \psi(t_0+\epsilon_j,.) \big)-T_{t_0}\big( \psi(t_0,.) \big) }{ \epsilon_j }
     \end{equation}

--- a/tex/frido/89_Equations_diff.tex
+++ b/tex/frido/89_Equations_diff.tex
@@ -694,7 +694,7 @@ Par conséquent \( y'(t)=R'(t)y_0=AR(t)y_0=Ay(t)\).
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{theorem}     \label{ThoNYEXqxO}
-    Soit \( I\) un intervalle de \( \eR\) et une fonction \( M\colon \eR\to \aL(\eR^n,\eR^n)\). Si les composantes \( M_{ij}\) sont des fonctions continues sur \( I\) alors :
+    Soient \( I\) un intervalle de \( \eR\) et \( M\colon \eR\to \aL(\eR^n,\eR^n)\) une fonction. Si les composantes \( M_{ij}\) sont des fonctions continues sur \( I\) alors :
     \begin{enumerate}
         \item
     pour tout \( t_0\in I\) et pour tout \( y_0\in R^n\) le système

--- a/tex/frido/91_vars_al.tex
+++ b/tex/frido/91_vars_al.tex
@@ -389,7 +389,7 @@ Notez que nous avons passé sous le silence la difficulté d'inverser la dériv�
 
 Nous dirons tout un tas de chose sur l'indépendance et la variance en \ref{subsecTTHohur}, mais pour l'instant nous allons mentionner et démontrer déjà ceci :
 \begin{lemma}   \label{LemVarXpYsmindep}
-    Soit \( X\) et \( Y\) deux variables aléatoires indépendantes et identiquement distribuées. Alors
+    Soient \( X\) et \( Y\) deux variables aléatoires indépendantes et identiquement distribuées. Alors
     \begin{equation}
         \Var(X+Y)=\Var(X)+\Var(Y).
     \end{equation}
@@ -802,7 +802,7 @@ La probabilité conditionnelle à \( B\) est quelque chose qui ne tient compte q
 \end{definition}
 
 \begin{definition}      \label{DEFooEYVCooCeyOXW}
-    Soit \( A\in\tribA\) un événement et \( \tribF\) une sous tribu de \( \tribA\). Nous définissons\index{espérance!conditionnelle!événement} \( P(A|\tribF)\) par
+    Soient \( A\in\tribA\) un événement et \( \tribF\) une sous-tribu de \( \tribA\). Nous définissons\index{espérance!conditionnelle!événement} \( P(A|\tribF)\) par
     \begin{equation}
         P(A|\tribF)=E(\mtu_{A}|\tribF).
     \end{equation}

--- a/tex/frido/96_Martingales.tex
+++ b/tex/frido/96_Martingales.tex
@@ -178,7 +178,7 @@ Notons en particulier que la variable aléatoire \( M_{\infty}\) est presque sû
     \begin{equation}    \label{EqRVoKxsN}
         (T\wedge n)(\omega)\to T(\omega)
     \end{equation}
-    pour tout \( \omega\) tel que \( T(\omega)=k\) pour tout \( k\in \eN\). Soit donc \( \omega\in \Omega\) tel que \( T(\omega)=k\) et \( n>k\). Nous avons
+    pour tout \( \omega\) tel que \( T(\omega)=k\) pour tout \( k\in \eN\). Soient donc \( \omega\in \Omega\) tel que \( T(\omega)=k\) et \( n>k\). Nous avons
     \begin{equation}
         (T\wedge n)(\omega)=T(\omega)\wedge n=k=T(\omega).
     \end{equation}
@@ -220,7 +220,7 @@ Un cas particulier intéressant de ce théorème \ref{ThoQMsRbkp} est le cas \( 
 \end{remark}
 
 \begin{theorem}[Premier théorème d'arrêt de Doob\cite{FUFFxBX}] \label{ThoZTrdjtZ}
-    Soit \( (X_n)\) une martingale et \( T\) un temps d'arrêt; tous deux pour la filtration \( (\tribF_n)\). Nous supposons qu'une des trois propriétés suivantes soit vérifiée :
+    Soient \( (X_n)\) une martingale et \( T\) un temps d'arrêt; tous deux pour la filtration \( (\tribF_n)\). Nous supposons qu'une des trois propriétés suivantes soit vérifiée :
     \begin{enumerate}
         \item
             \( T\) est presque sûrement bornée.
@@ -295,7 +295,7 @@ Attention : en vertu de la proposition \ref{PropWoywYG} et surtout de l'exemple 
 % TODO : la preuve est dans la référence.
 
 \begin{proposition}[\cite{HPVCqkr}] \label{PropAYJpGsc}
-    Soit \( (M_n)\) une martingale et \( T\) un temps d'arrêt (pour la même filtration \( (\tribB_n)\)). Alors le processus \( V_n=M_{n\wedge T}\) est une martingale.
+    Soient \( (M_n)\) une martingale et \( T\) un temps d'arrêt (pour la même filtration \( (\tribB_n)\)). Alors le processus \( V_n=M_{n\wedge T}\) est une martingale.
 \end{proposition}
 
 \begin{proof}

--- a/tex/outils_math/calcul_differentiel.tex
+++ b/tex/outils_math/calcul_differentiel.tex
@@ -295,7 +295,7 @@ qui est une approximation d'autan meilleure que $\Delta x$ est petit.
 \section{Recherche d'extrema}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Soit une fonction $f\colon I\to \eR$, et soit $a\in I$. Si $f'(a)>0$, alors la tangente au graphe de $f$ au point $\big( a,f(a) \big)$ sera une droite croissante (coefficient directeur positif). Cela ne veut pas spécialement dire que la fonction elle-même sera croissante, mais en tout cas cela est un bon indice.
+Soit $f\colon I\to \eR$ une fonction, et soit $a\in I$. Si $f'(a)>0$, alors la tangente au graphe de $f$ au point $\big( a,f(a) \big)$ sera une droite croissante (coefficient directeur positif). Cela ne veut pas spécialement dire que la fonction elle-même sera croissante, mais en tout cas cela est un bon indice.
 
 \begin{example}
 	Si $f(x)=x^2$, il est connu que $f'(x)=2x$. Nous avons donc que $f'$ est positive si $x\geq 0$ et $f'>$ est négative si $x<0$. Cela correspond bien au fait que $x^2$ est décroissante sur $\mathopen] -\infty , 0 \mathclose[$ et croissante sur $\mathopen] 0 , \infty \mathclose[$.

--- a/tex/outils_math/plusieurs_variables.tex
+++ b/tex/outils_math/plusieurs_variables.tex
@@ -347,7 +347,7 @@ Alors la condition \eqref{EqCondDiffabelOM} s'écrit
 Nous avons vu que l'existence des deux dérivées partielles ne permettait pas de conclure à la différentiabilité. La différentiabilité d'une fonction peut néanmoins être déduites d'une étude plus précise des dérivées partielles. Nous avons pour cela les propositions \ref{PropExistDiffUnOM} et \ref{PropExistDiffDeuxOM}
 
 \begin{proposition} \label{PropExistDiffUnOM}
-    Soit $f$ une fonction de $x$ et $y$ et un point $(a,b)\in\eR^2$. Si les nombres $\partial_xf(a,b)$ et $\partial_yf(a,b)$ existent et s'il existe une fonction $\alpha\colon \eR\to \eR$ telle que
+    Soient $f$ une fonction de $x$ et $y$, et $(a,b)\in\eR^2$ un point. Si les nombres $\partial_xf(a,b)$ et $\partial_yf(a,b)$ existent et s'il existe une fonction $\alpha\colon \eR\to \eR$ telle que
     \begin{equation}        \label{eqCritDifffabsrtOM}
         \begin{aligned}[]
             f(x,y)=f(a,b)&+\frac{ \partial f }{ \partial x }(a,b)(x-a)+\frac{ \partial f }{ \partial y }(a,b)(y-b)\\

--- a/tex/outils_math/theorie_generale.tex
+++ b/tex/outils_math/theorie_generale.tex
@@ -39,7 +39,7 @@ tandis que la première est presque de la forme $f'/f$ :
 					\section{Primitives et surfaces}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Soit $f\colon \eR\to \eR$, une fonction continue, et $x\in\eR$. Pour chaque $x\in\eR$, nous pouvons considérer le nombre $F(x)$ défini par
+Soient $f\colon \eR\to \eR$  une fonction continue et $x\in\eR$. Pour chaque $x\in\eR$, nous pouvons considérer le nombre $F(x)$ défini par
 \begin{equation}
 	F(x)=\int_a^x f(t)dt.
 \end{equation}


### PR DESCRIPTION
**Ceci est un travail en cours**

On applique les règles suivantes :

* Accord de « Soit » :
    « Soient $f$ et $g$ deux fonctions. »
au lieu de
    « Soit $f$ et $g$ deux fonctions. ».

* Accord de « tel que » :
    « Soient $f$ et $g$ deux fonctions telles que »

* D'abord le symbole, ensuite sa nature :
    « Soit $A$ un annneau commutatif »
est meilleur que
    « Soit un anneau commutatif $A$ ».

* « Soit $f$ une fonction. Supposons que »
est préférable à
    « Soit $f$ une fonction et supposons que »

Quelques coquilles diverses sont éliminées.