### PR TITLE
Relecture de « Topology »

### DIFF
--- a/tex/exercices/listeExo.tex
+++ b/tex/exercices/listeExo.tex
@@ -132,7 +132,7 @@ Si $A_n$ est une suite d'ensemble, le symbole
 \end{equation}
 désigne l'ensemble des éléments qui sont dans $A_n$ pour tout $n\in\eN$. Remarquez que l'infini \emph{n'est pas} un élément de $\eN$ ! L'intersection se fait donc de $n=1$ à l'infini; l'infini non compris.
 
-Prenons comme exemple le cas du point \ref{ItemF0072} de l'exercice \ref{exo0072}. Étant donné que $A_n=\mathopen]-\frac{1}{ n },\frac{1}{ n }\mathclose[$, on pourrait croire que $A_{\infty}=\mathopen]0,0\mathclose[=\emptyset$, et que par conséquent, l'intersection $\cap_{n=1}^{\infty}$ est vide.
+Prenons comme exemple le cas du point \ref{ItemF0072} de l'exercice \ref{exo0072}. Étant donné que $A_n=\mathopen]-\frac{1}{ n },\frac{1}{ n }\mathclose[$, on pourrait croire que $A_{\infty}=\mathopen]0,0\mathclose[=\emptyset$, et que par conséquent, l'intersection $\bigcap_{n=1}^{\infty}$ est vide.
 
 %---------------------------------------------------------------------------------------------------------------------------
 					\subsection{Exercices ultra basiques}

--- a/tex/exocorr/corr005.tex
+++ b/tex/exocorr/corr005.tex
@@ -30,7 +30,7 @@ Now we can extend this $\tilde\varphi$ to the map $\dpt{ \hat{\tilde\varphi} }{ 
 which is smooth.
 
 How to choice $I$ ?  For each $x\in\mU$, the point $(x,0)$ belongs to the open set $W\subset \eR^2$. Therefore there exists a non empty neighbourhood $I_x$ of $0$ such that $(x,I_x)\subset W$. Taking if necessary a smallest chart $\mU'$ instead of $\mU$, one can take the non empty set
-$I=\cap_{x\in\mU}I_x$.
+$I=\bigcap_{x\in\mU}I_x$.
 
 
 \end{corrige}

--- a/tex/exocorr/corr0071.tex
+++ b/tex/exocorr/corr0071.tex
@@ -13,9 +13,9 @@
 		Plus généralement, dans un espace topologique non connexe, les composantes connexes sont ouvertes et fermées.
 	\item Dans $\eR^n$, n'importe quel ensemble de $8$ points est compact (fermé et borné). Nous pouvons aussi montrer que n'importe quel espace topologique qui possède un nombre fini de points est compact. 
 
-En effet, soit l'ensemble $A=\{ a_1,\ldots a_n \}$, et prenons un recouvrement de cet ensemble par des ouverts $\mO_{\alpha}$. Comme c'est un recouvrement, nous avons $A\subseteq\cup_{\alpha}\mO_{\alpha}$. Soit $\alpha_1$ tel que $a_1\in\mO_{\alpha_1}$ (ceci existe parce que $a_1$ est dans un des $\mO_{\alpha}$). Plus généralement, nous prenons $i$ tel que $a_i$ soit dans $\mO_{\alpha_i}$ pour $i=1,\ldots n$. 
+En effet, soit l'ensemble $A=\{ a_1,\ldots a_n \}$, et prenons un recouvrement de cet ensemble par des ouverts $\mO_{\alpha}$. Comme c'est un recouvrement, nous avons $A\subseteq\bigcup_{\alpha}\mO_{\alpha}$. Soit $\alpha_1$ tel que $a_1\in\mO_{\alpha_1}$ (ceci existe parce que $a_1$ est dans un des $\mO_{\alpha}$). Plus généralement, nous prenons $i$ tel que $a_i$ soit dans $\mO_{\alpha_i}$ pour $i=1,\ldots n$.
 
-Maintenant, $A\subseteq\cup_{i=1}^n\mO_{\alpha_i}$, ce qui fait que nos $\mO_{\alpha_i}$ forment un sous-recouvrement fini de $A$.
+Maintenant, $A\subseteq\bigcup_{i=1}^n\mO_{\alpha_i}$, ce qui fait que nos $\mO_{\alpha_i}$ forment un sous-recouvrement fini de $A$.
 
 	\item Une hélice $\{ (cos(t),sin(t),t) \tq t \in \eR\}$ dans $\eR^3$. Une simple droite dans $\eR^2$ est bon aussi.
 	\item Pour obtenir un exemple non trivial (pas $\emptyset$ dans un espace métrique, ni un espace topologique métrique borné vu comme sous-espace de lui-même), il faut se placer dans un espace non connexe. Par exemple dans l'espace topologique formé de l'une union disjointe de deux sphères $S^2 \sqcup S^2$, chaque sphère est ouverte, fermée et bornée.

--- a/tex/exocorr/corr0075.tex
+++ b/tex/exocorr/corr0075.tex
@@ -17,7 +17,7 @@ Montrons la première relation : soit $x \in \Omega$. Alors nous avons les équi
 \end{equation*}
 où $\neg$ désigne la négation logique (et $n$ est élément de $\eN$).
 
-La deuxième relation se traite de façon similaire. On peut également la déduire de la première relation de la manière suivante~: pour montrer que ${\left(\cap_n A_n\right)}^c = \cup_n ({A_n}^c)$, il suffit de poser $B_n = A_n^c$, de prendre le complémentaire dans les deux membres et d'utiliser le fait que ${(X^c)}^c = X$ pour se ramener à la première relation.
+La deuxième relation se traite de façon similaire. On peut également la déduire de la première relation de la manière suivante~: pour montrer que ${\left(\bigcap_n A_n\right)}^c = \bigcup_n ({A_n}^c)$, il suffit de poser $B_n = A_n^c$, de prendre le complémentaire dans les deux membres et d'utiliser le fait que ${(X^c)}^c = X$ pour se ramener à la première relation.
 
 
 \end{corrige}

--- a/tex/exocorr/exo0072.tex
+++ b/tex/exocorr/exo0072.tex
@@ -12,7 +12,7 @@ Déterminez l'intérieur, l'adhérence et la frontière des sous-ensembles de $\
 \item $ \eZ $
 \item $ \eQ $
 \item $ \{ \frac{1}{i} \mid i \in \eZ_0 \} $
-\item\label{ItemF0072} $ \cap_{n = 1}^{ \infty} ] -\frac{1}{n} , \frac{1}{n} [ $
+\item\label{ItemF0072} $ \bigcap_{n = 1}^{ \infty} ] -\frac{1}{n} , \frac{1}{n} [ $
 \end{enumerate}
 
 \corrref{0072}

--- a/tex/frido/185_topologie.tex
+++ b/tex/frido/185_topologie.tex
@@ -704,7 +704,7 @@ L'intersection d'une \emph{infinité} d'ouverts n'est pas spécialement un ouver
 \[ 
   \mO_i=]1,2+\frac{ 1 }{ i }[.
 \]
-Tous les ensembles $\mO_i$ contiennent le point $2$ qui est donc dans l'intersection. Mais quel que soit le $\epsilon>0$ que l'on choisisse, le point $2+\epsilon$ n'est pas dans $\mO_{(1/\epsilon)+1}$. Donc aucun point au-delà de $2$ n'est dans l'intersection, ce qui prouve que $2$ ne possède pas de voisinages contenus dans $\cap_{i=1}^{\infty}\mO_i$.
+Tous les ensembles $\mO_i$ contiennent le point $2$ qui est donc dans l'intersection. Mais quel que soit le $\epsilon>0$ que l'on choisisse, le point $2+\epsilon$ n'est pas dans $\mO_{(1/\epsilon)+1}$. Donc aucun point au-delà de $2$ n'est dans l'intersection, ce qui prouve que $2$ ne possède pas de voisinages contenus dans $\bigcap_{i=1}^{\infty}\mO_i$.
 \end{remark}
 
 \begin{proposition}

--- a/tex/frido/2_Integration.tex
+++ b/tex/frido/2_Integration.tex
@@ -603,7 +603,7 @@ m(R)=\sum_{(k_1,\ldots,k_p)\in K} m(R_{(k_1,\ldots,k_p)}),
 \] 
 où $K=\{1,\ldots,n_1\}\times\{1,\ldots,n_2\}\times\ldots \times\{1,\ldots,n_p\}$.
 \end{lemma}
-Le lemme \ref{meas_sous} suggère de définir la mesure d'un ensemble borné pavable $P=\cup_{j=1}^{n}R_j$ comme la somme des mesures des pavés disjoints $R_j$, $j=1,\ldots, n$.
+Le lemme \ref{meas_sous} suggère de définir la mesure d'un ensemble borné pavable $P=\bigcup_{j=1}^{n}R_j$ comme la somme des mesures des pavés disjoints $R_j$, $j=1,\ldots, n$.
 \begin{definition}
 Une application $f:\eR^p\to\eR$ est dite \defe{application en escalier}{application!en escalier} sur $\eR^m$ si
   \begin{itemize}

--- a/tex/research/118_cstar.tex
+++ b/tex/research/118_cstar.tex
@@ -364,7 +364,7 @@ is an ideal in $C(X)$. Suppose that $E$ is not surjective. Then there exists som
 \[ 
 \cI_{\omega}=\ker\omega=\{f\in C(X)\tq \omega(f)=0\}.
 \]
- This $\cI_{\omega}$ can't contains any $\cI_x$ because they are maximal ideals. Then for all $x\in X$ , there exists a $f\in C(X)$ such that $f(x)=0$ with $f\notin\cI_{\omega}$. If $E$ is not surjective, then there exists a maximum ideal $\cI$, kernel of a character which is not in the image of $E$. In order this ideal to be included in none of the $\cI_x$, one needs that for all $x\in X$, there exists $f_x\in\cI$ such that $f_x(x)\neq 0$. Let $\mO_x$ be an open set on which $f_x\neq 0$. Since $X$ is compact, one can extract a finite subcovering $X=\cup_i\mO_{x_i}$. Now we build
+ This $\cI_{\omega}$ can't contains any $\cI_x$ because they are maximal ideals. Then for all $x\in X$ , there exists a $f\in C(X)$ such that $f(x)=0$ with $f\notin\cI_{\omega}$. If $E$ is not surjective, then there exists a maximum ideal $\cI$, kernel of a character which is not in the image of $E$. In order this ideal to be included in none of the $\cI_x$, one needs that for all $x\in X$, there exists $f_x\in\cI$ such that $f_x(x)\neq 0$. Let $\mO_x$ be an open set on which $f_x\neq 0$. Since $X$ is compact, one can extract a finite subcovering $X=\bigcup_i\mO_{x_i}$. Now we build
 \[ 
  g:=\sum_{i=1}^n|f_{x_i}|^2.
 \]

--- a/tex/research/120_cstar.tex
+++ b/tex/research/120_cstar.tex
@@ -283,7 +283,7 @@ There exists a suitable topology on this space, the \defe{hull-kernel topology}{
 \begin{equation}
   \overline{ W }=\{ \mI\in\Prim\cA\tq \cap W\subseteq \mI \}.
 \end{equation}
-where $\cap W=\cap_{\mJ\in W}\mJ$. The inclusion $\cap W\subseteq\mI$ is an inclusion of subsets of $\cA$.
+where $\cap W=\bigcap_{\mJ\in W}\mJ$. The inclusion $\cap W\subseteq\mI$ is an inclusion of subsets of $\cA$.
 
 \begin{proposition}
 This definition defines a topology. Namely, it fulfils the Kuratowsky axioms:

--- a/tex/research/131_noncommutative_geometry.tex
+++ b/tex/research/131_noncommutative_geometry.tex
@@ -1200,13 +1200,13 @@ We say that $a\in\cA$ is \defe{smooth}{smooth!in spectral triple} and we write $
 is smooth. The element $a$ is of class $C^k$ when $s\to\alpha_s(a)$ is $C^k$.
 
 \begin{proposition}
-An element $a\in\cA$ is smooth if and only if $a\in\cap_{n\in\eN}\dom(\delta^n)$.
+An element $a\in\cA$ is smooth if and only if $a\in\bigcap_{n\in\eN}\dom(\delta^n)$.
 \end{proposition}
 
 \begin{proof}
 If $a$ is smooth, the existence of the derivative of $s\to  e^{is| D |}a e^{-is| D |}$ makes that $a\in\dom\delta$ because the derivative of this map is precisely $\delta$. A few computation shows that the second derivative of this map is $\delta^2$.
 
-If, on the other hand, $a\in\cap_{n\in\eN}\dom(\delta^n)$, we have existence of all the derivatives of $s\to\alpha_s(a)$ and continuity is given by derivability
+If, on the other hand, $a\in\bigcap_{n\in\eN}\dom(\delta^n)$, we have existence of all the derivatives of $s\to\alpha_s(a)$ and continuity is given by derivability
 \begin{probleme}
 	Is that justification correct?
 \end{probleme}

--- a/tex/research/143_Lie_gp_and_subgp.tex
+++ b/tex/research/143_Lie_gp_and_subgp.tex
@@ -67,7 +67,7 @@ First, $G_0^{-1}$ is connected because  it is homeomorphic to $G_0$ in $G$. The 
 
 For all $x\in G$, we have $e=xex^{-1}\in xG_0x^{-1}$, but $xG_0x^{-1}$ is connected. Hence $xG_0x^{-1}\subseteq G_0$, which proves that $G_0$ is an invariant subset of $G$.
 
-Lateral classes $xG_0$ are connected because the left multiplication is an homeomorphism. They are moreover \emph{maximal} connected subsets because, if $xG_0\subset H$ (proper inclusion) with a connected $H$, then $G_0\subset x^{-1}H$ (still proper inclusion). But the definition of $G_0$ is that this proper inclusion is impossible. Therefore, the sets of the form $xG_0$ are maximally connected sets. It is clear that $\cup_{g\in G}gG_0=G$.
+Lateral classes $xG_0$ are connected because the left multiplication is an homeomorphism. They are moreover \emph{maximal} connected subsets because, if $xG_0\subset H$ (proper inclusion) with a connected $H$, then $G_0\subset x^{-1}H$ (still proper inclusion). But the definition of $G_0$ is that this proper inclusion is impossible. Therefore, the sets of the form $xG_0$ are maximally connected sets. It is clear that $\bigcup_{g\in G}gG_0=G$.
 
 Notice that the last point works with $G_0x$ too.
 \end{proof}

--- a/tex/research/147_topo.tex
+++ b/tex/research/147_topo.tex
@@ -6,7 +6,7 @@
 \section{Main definitions}
 %+++++++++++++++++++++++++
 
-As for notations, when we have a topological space $X$ and a point $x\in X$, we denote by $\mV(x)$ the set of neighbourhood of $x$. If $F$ is a subset of $X$, we denote by $\overline{F}$ the closure of $F$ and by $\Int{F}$, its interior.
+As for notations, when we have a topological space $X$ and a point $x\in X$, we denote by $\mV(x)$ the set of neighbourhoods of $x$. If $F$ is a subset of $X$, we denote by $\overline{F}$ the closure of $F$ and by $\Int{F}$, its interior.
 
 \begin{definition}
 Let $\mO$ be a topology on a set $X$. A subset $\mB\subset\mO$ (the elements of $\mB$ are subsets of $X$) is a \defe{basis of topology}{basis!of topology} $\mO$ of $X$ when
@@ -100,7 +100,7 @@ Let $(x_i)$ be the dense sequence. We consider $B_{i,k}$, the open ball centred 
 \end{proof}
 
 \begin{definition}
-A subset of a topological space is \defe{connected}{connected part in topological space} if it cannot be written as an union of disjoints open sets.
+A subset of a topological space is \defe{connected}{connected part in topological space} if it cannot be written as an union of disjoint open sets.
 \end{definition}
 
 If $A$ is a part of the topological space $X$, the \defe{boundary}{boundary} is the subset of $X$ defined by
@@ -113,12 +113,12 @@ In a topological space, any path connected part is connected.
 \end{lemma}
 
 \begin{theorem}
-Let $E$ be a topological space and $A,B$ two connected parts of $E$. If $A$ intersect $B$ and $\complement B$, then $A$ intersect $\Fr(B)$.\label{tho:doine}
+Let $E$ be a topological space and $A,B$ two connected parts of $E$. If $A$ intersects $B$ and $\complement B$, then $A$ intersects $\Fr(B)$.\label{tho:doine}
 \end{theorem}
 
 
 \begin{proposition}
-Let $X$ be a topological space and $A$, $B$ two subsets of $X$ such that $A\cup B$ is closed and there exists $A'$, $B'$, two disjoints sets containing respectively the closure of $A$ and $B$. Then $A$ and $B$ are separately closed.\label{prop:sep_ferme}
+Let $X$ be a topological space and $A$, $B$ two subsets of $X$ such that $A\cup B$ is closed and there exist $A'$, $B'$, two disjoint sets containing respectively the closure of $A$ and $B$. Then $A$ and $B$ are separately closed.\label{prop:sep_ferme}
 \end{proposition}
 
 \begin{proof}
@@ -159,7 +159,7 @@ A subset $A$ of a metric space is \defe{relatively compact}{compact!relatively} 
 \end{definition}
 
 \begin{definition}
-An \defe{Hausdorff space}{Hausdorff space} is a topological space in which any two distinct elements have disjoints neighbourhoods.
+An \defe{Hausdorff space}{Hausdorff space} is a topological space in which any two distinct elements have disjoint neighbourhoods.
 \end{definition}
 
 \begin{lemma}
@@ -170,7 +170,7 @@ If a set is Hausdorff for a topology $\tau_1$ and compact in a weaker topology $
 If $K$ is a compact topological space and $E$ a separated\quext{Comment on dit un espace s\'epar\'e?} one and if $\dpt{f}{K}{E}$ is a continuous bijection, then $f$ is an homeomorphism. \label{lem:wiki}
 \end{proposition}
 
-A space is \defe{normal}{normal!space} when for all disjoints closed subset $E$ and $F$ of the topological space $X$, there exists neighbourhoods $\mU$ and $\mV$ of $E$ and $F$ which are disjoints too. A topological result says that a compact Hausdorff space is normal.
+A space is \defe{normal}{normal!space} when for all disjoint closed subset $E$ and $F$ of the topological space $X$, there exist neighbourhoods $\mU$ and $\mV$ of $E$ and $F$ which are disjoint too. A topological result says that a compact Hausdorff space is normal.
 
 \begin{lemma}
 If $X$ is a normal space, $F$ a closed subset of $X$ and $\mU$ an open set containing $F$, then there exists a continuous function $\dpt{f}{X}{[0,1]}$ such that $f(F)=0$ and $f(X\setminus\mU)=1$. \label{lem:Urysohn}
@@ -402,7 +402,7 @@ For example, when a distance is left invariant, the left translations are isomet
 \begin{proposition}
     Let $G$ be a topological group.
 \begin{itemize}
-\item $G$ is metrisable if and only if there exists a countable fundamental system of neighbourhood of $e$ (the neutral) whose intersection is only $e$.
+\item $G$ is metrisable if and only if there exists a countable fundamental system of neighbourhoods of $e$ (the neutral) whose intersection is only $e$.
 \item In this case, the topology of $G$ ca be defined by a left invariant distance or a right invariant distance.
 \end{itemize}
 \end{proposition}
@@ -421,7 +421,7 @@ Let $G$ be a metrisable group. A sequence $(a_n)$ in $G$ is a Cauchy sequence fo
 
 The point is that if a sequence is a Cauchy sequence for a left invariant distance, then it is a Cauchy sequence for \emph{any} left invariant distance. This yields the important conclusion: in metrisable groups, the notion of Cauchy sequence is a topological notion which only depends on the neighbourhood notion.
 
-A right invariant Cauchy sequence is the same but with $x_nx_m^{-1}$ instead of $x_n^{-1} x_m$. By definition of a topological group, the map $x\to x^{-1}$ is continuous. Thus, if all the left Cauchy sequence are convergent, then all the right Cauchy sequences are convergent. In this case, the group $G$ is said \defe{complete}{complete!topological group}.
+A right invariant Cauchy sequence is the same but with $x_nx_m^{-1}$ instead of $x_n^{-1} x_m$. By definition of a topological group, the map $x\to x^{-1}$ is continuous. Thus, if all the left Cauchy sequences are convergent, then all the right Cauchy sequences are convergent. In this case, the group $G$ is said \defe{complete}{complete!topological group}.
 
 If the group is abelian, we have only one notion of Cauchy sequence, and it is independent of the metric.
 

--- a/tex/research/147_topo.tex
+++ b/tex/research/147_topo.tex
@@ -139,7 +139,7 @@ Let $X$ be a topological space, $K\subset X$ a compact and $\dpt{\phi}{K}{X}$ a 
 \end{proposition}
 
 \begin{definition}
-A covering $\{ X_i \}$ of the topological space $E$ is a covering such that for each $x\in E$, there exists a neighbourhood $V$ such that $V\cap X_i\neq \emptyset$ only for a finite subset of $X_i$.
+  A family $\{ X_i \}_{i\in I}$ of subsets of a topological space $E$ is said to be \defe{locally finite}{family!locally finite} if each $x\in E$ has a neighbourhood $V$ such that $V\cap X_i \neq \emptyset$ for only finitely many values of $i$.
 \end{definition}
 
 

--- a/tex/research/147_topo.tex
+++ b/tex/research/147_topo.tex
@@ -183,7 +183,7 @@ A metric space is \defe{complete}{complete!metric space} when any Cauchy sequenc
 Pay attention not to be confused with a characterization of a \emph{closed} subset: the limit of any converging sequence lies in the space.
 
 \begin{definition}
-Let $E$ and $F$ be two spaces in duality\quext{Tu devras trouver la def exacte de cela dans le bouquin d'analyse fonctionelle de Mir}; if $A\subset A$ and $B\subset F$, we say that $A$ \defe{separates}{separate} $B$ is $\forall x\neq y\in B$, $\exists a\in A$ such that $\hat{a}(x)\neq\hat{a}(y)$ where the hat denotes the duality. \label{def:separe}
+Let $E$ and $F$ be two spaces in duality\quext{Tu devras trouver la def exacte de cela dans le bouquin d'analyse fonctionelle de Mir}; if $A\subset E$ and $B\subset F$, we say that $A$ \defe{separates}{separate} $B$ if $\forall x\neq y\in B$, $\exists a\in A$ such that $\hat{a}(x)\neq\hat{a}(y)$ where the hat denotes the duality. \label{def:separe}
 \end{definition}
 
 For an Hausdorff $X$ space, we denote by $C(X)$\nomenclature{$C(X)$}{Space of continuous functions}\label{pg_def_Cz } the space of all continuous functions on $X$. For a locally compact space $X$, the set $C_0(X)$\nomenclature{$C_0(X)$}{Space of continuous functions which decrease to zero at infinity in a certain sense} contains continuous functions which decrease to zero at infinity in the sense that for any $\varepsilon>0$, there exists a compact set $K$ such that $|f(X)|<\varepsilon$ for all $x$ outside $K$.

--- a/tex/research/147_topo.tex
+++ b/tex/research/147_topo.tex
@@ -78,7 +78,7 @@ A topological space is \defe{separable}{separable!topological space} when it adm
 \end{definition}
 
 \begin{lemma}
-Let $\Gamma$ be a family of subsets of a set $X$ such that $X=\cup_{A\in\Gamma}A$.
+Let $\Gamma$ be a family of subsets of a set $X$ such that $X=\bigcup_{A\in\Gamma}A$.
 
 There exists a topology on $X$ of basis $\Gamma$ if and only if the intersection of any \emph{finite} subfamily of $\Gamma$ can be written as the union of elements of $\Gamma$.
 \label{lem:topo_base}
@@ -247,7 +247,7 @@ A metric space is \defe{separable}{separable} if there exists a subset at most c
 \begin{proposition}
 If $E$ is a metric locally compact space, then the following are equivalent:
 \begin{enumerate}
-\item There exists an increasing sequence $(A_n)$ of open relatively compacts subset of $E$ such that $\overline{A_n}\subset A_{n+1}$ and $E=\cup_n A_n$,
+\item There exists an increasing sequence $(A_n)$ of open relatively compacts subset of $E$ such that $\overline{A_n}\subset A_{n+1}$ and $E=\bigcup_n A_n$,
 
 \item $E$ is a countable union of compact subsets,
 


### PR DESCRIPTION
À l'exception de quelques coquilles, je me suis permis de remplacer la définition d'un recouvrement localement fini par celle d'une famille de sous-ensembles localement finie ; en effet, il s'agit de la même définition tout en étant plus générale. 

