### PR TITLE
Les macros \quext et \quexto

### DIFF
--- a/e_mazhe.tex
+++ b/e_mazhe.tex
@@ -844,7 +844,7 @@
 \newcommand{\tq}{\text{ tel que }}          %TODO : il y a un paquet qui doit être changé en \st
 \newcommand{\st}{\text{ such that }} 
 \newcommand{\tqs}{\text{ tels que }}
-\newcommand{\quext}[1]{ \footnote{\textsf{#1}}  }
+\newcommand{\quext}[1]{\footnote{\textsf{#1}}}
 \newcommand{\info}[1]{\texttt{#1}}
 
 \newcommand{\normal}{\lhd}  % Cette notation n'est plus censée être utilisée.

--- a/e_mazhe.tex
+++ b/e_mazhe.tex
@@ -660,7 +660,6 @@
 \newcommand{\invtible}{^{\times}}   % Cette commande est en attendant de trouver un symbole plus spécifique à mettre sur les ensembles pour désigner leur partir inversible.
 \newcommand{\osint}{\widetilde{\int}}
 \newcommand{\Lie}[1]{\mathfrak{Lie}(#1)}
-\newcommand{\quexto}[1]{ \footnote{\textsf{#1}}  }
 \newcommand{\qvect}[4]{(#1,#2,#3,#4)}
 \newcommand{\osiint}{\widetilde{\iint}}
 \newcommand{\osiiint}{\widetilde{\iiint}}

--- a/tex/research/MQ.tex
+++ b/tex/research/MQ.tex
@@ -612,7 +612,7 @@ Since we know that with this definition of $\ket{k,\sigma}$, the eigenvalue of $
 \end{equation}
 where $N(p)$ is a normalization to be discussed later. With this construction, we have an eigenvector for any possible eigenvalue for $P\hmu$. We have to show that these vectors are linearly independent.
 
-The set of the $\ket{p,\sigma}$ with different $p$ is free in $\pH$ because they are eigenvectors for different eigenvalue of an hermitian operator\quexto{I did not checked that it is sufficient}. There are no reason to think that the set of operators $P\hmu$ is complete; in other words, it remains not clear that there exist only one way to diagonalise the all the $P\hmu$. The function of the extra label $\sigma$ is to label different linearly independent vectors with same eigenvalue for $P$.
+The set of the $\ket{p,\sigma}$ with different $p$ is free in $\pH$ because they are eigenvectors for different eigenvalue of an hermitian operator\quext{I did not checked that it is sufficient}. There are no reason to think that the set of operators $P\hmu$ is complete; in other words, it remains not clear that there exist only one way to diagonalise the all the $P\hmu$. The function of the extra label $\sigma$ is to label different linearly independent vectors with same eigenvalue for $P$.
 
 From now, we are interested in $\ket{k,\sigma}$ and $N(p)$.
 
@@ -677,7 +677,7 @@ But we have no constraint on the $D$'s: it must just form a representation of th
 
 The physical interpretation is the following\label{pg:phyz_reprez}: each type of particle has its own representation. When we consider a Hilbert space on which $U(\Lambda)$ acts via one given representation of the little group, we consider the Hilbert space which describes the corresponding particle. Note that the little group depends on the choice of $k$, and therefore depends on the particle which is studied (massive or not).
 
-In this sense, a particle is a representation of the Poincaré group\quexto{I think that the irreducibility of a representation is related to \emph{elementary} particles.}. In particular, the nature of the index $\sigma$ can change from the one representation to the other.
+In this sense, a particle is a representation of the Poincaré group\quext{I think that the irreducibility of a representation is related to \emph{elementary} particles.}. In particular, the nature of the index $\sigma$ can change from the one representation to the other.
 
 \begin{remark}
 As far as normalization is concerned, we will pose


### PR DESCRIPTION
Supprime la macro \quexto, un doublon de la macro \quext, et corrige l'espacement dans \quext.