### PR TITLE
(typographie) Dit à babel que «=\og et »=\fg

### DIFF
--- a/e_mazhe.tex
+++ b/e_mazhe.tex
@@ -77,7 +77,12 @@
 \usepackage{array}
 
 \usepackage[fr]{exocorr}
+
 \usepackage[english,french]{babel}
+\frenchsetup{
+  og=«,fg=»
+}
+
 \usepackage{listingsutf8}   % Has to be called after babel
 
 


### PR DESCRIPTION
et ainsi une espace insécable sera ajoutée après « et avant ».