### PR TITLE
espaces vectoriels normée → espaces vectoriels normés

### DIFF
--- a/tex/frido/75_series_fonctions.tex
+++ b/tex/frido/75_series_fonctions.tex
@@ -302,7 +302,8 @@ Avant de vous lancer, relisez une bonne fois les définitions de convergence abs
     Ce dernier est arbitrairement petit lorsque \( N\) est grand. Notons que nous avons utilisé l'hypothèse de convergence normale.
 \end{proof}
 
-La même propriété, avec la même démonstration, tient dans le cas d'espaces vectoriels normée.
+La même propriété, avec la même démonstration, tient dans le cas d'espaces vectoriels normés.
+
 \begin{proposition} \label{PropOMBbwst}
     Soient \( E\) et \( F\), deux espaces vectoriels normés, \( \Omega\) une partie ouverte de \( E\) et une suite de fonctions \( u_n\colon \Omega\to F\) convergeant normalement sur \( \Omega\), c'est-à-dire que \( \sum_n\| u_n \|_{\infty}\) converge, la norme \( \| . \|_{\infty} \) devant être comprise comme la norme supremum sur \( \Omega\). Alors la fonction \( u=\sum_nu_n\) est continue sur \( \Omega\).
 \end{proposition}


### PR DESCRIPTION
Juste une typo d'une lettre, corrigée ici.
Avec la version de lefrido.pdf actuelle, c'est en page 920, https://laurent.claessens-donadello.eu/pdf/lefrido.pdf#page=920&zoom=auto,-274,822