### PR TITLE
Quelques typos sur 90_Equations_diff.tex

### DIFF
--- a/tex/frido/90_Equations_diff.tex
+++ b/tex/frido/90_Equations_diff.tex
@@ -12,7 +12,7 @@ Dans cette section nous étudions les équations différentielles du type
 \begin{subequations}
     \begin{numcases}{}
         y'(t)=f\big( t,y(t) \big)\\
-        y(t_0)=y_0
+        y(t_0)=y_0.
     \end{numcases}
 \end{subequations}
 
@@ -25,7 +25,7 @@ Nous considérons l'équation différentielle
 \begin{subequations}
     \begin{numcases}{}
         y'(t)=f\big( t,y(t) \big)\\
-        y(t_0)=y_0
+        y(t_0)=y_0,
     \end{numcases}
 \end{subequations}
 où \( f\colon I\times \Omega\to \eR^n\) est continue et \( \Omega\) ouvert dans \( \eR^n\). Soit la solution maximale \( y_M\colon J_M=\mathopen] t_{min} , t_{max} \mathclose[\to \Omega\). Si \( t_{max}<\sup(I)\) alors \( y_M(t)\) sort de tout compact de \( \Omega\) lorsque \( t\to t_{max}\).
@@ -67,7 +67,7 @@ Soit \( K\) un compact de \( \Omega\) et nous considérons une suite \( (t_m)\) 
     \begin{subequations}
         \begin{numcases}{}
             y'=f(t,y)\\
-            y(t_0)=y_0
+            y(t_0)=y_0,
         \end{numcases}
     \end{subequations}
     avec \( f\colon U=I\times \Omega\to \eR^n\) où \( I\) est ouvert dans \( \eR\) et \( \Omega\) ouvert dans \( \eR^n\). Nous supposons que \( f\) est continue sur \( U\) et localement Lipschitz par rapport à \( y\).
@@ -90,7 +90,7 @@ Soit \( K\) un compact de \( \Omega\) et nous considérons une suite \( (t_m)\) 
 \begin{proof}
     L'hypothèse \( t_{max}<\sup(I)\) signifie que la solution finit d'exister avant que les hypothèses sur \( f\) cessent d'être vraies. C'est-à-dire que la solution maximale est moindre que ce que nous aurions pu espérer.
 
-Soit un compact \( K\).Supposons que que pour tout \( t_0<t_{max}\) il existe \( t\in\mathopen] t , t_{max} \mathclose[\) tel que \( y_M(t)\in K\). Alors cela crée une suite \( t_k\) dans \( J\) telle que \( y_M(t_k)\) est dans \( K\). Comme dans le théorème de la fuite des compacts nous concluons l'impossibilité de la chose.
+Soit un compact \( K\). Supposons que que pour tout \( t_0<t_{max}\) il existe \( t\in\mathopen] t , t_{max} \mathclose[\) tel que \( y_M(t)\in K\). Alors cela crée une suite \( t_k\) dans \( J\) telle que \( y_M(t_k)\) est dans \( K\). Comme dans le théorème de la fuite des compacts nous concluons l'impossibilité de la chose.
 
     Donc pour tout compact \( K\) de \( \Omega\), il existe \( T<t_{max}\) tel que \( y_M(t)\in \Omega\setminus K\) pour tout \( t\in\mathopen[ T , t_{max} [\). En prenant des boules fermées de plus en plus grandes en guise de compacts nous concluons que
         \begin{equation}
@@ -113,10 +113,10 @@ Soit un compact \( K\).Supposons que que pour tout \( t_0<t_{max}\) il existe \(
     \begin{subequations}
         \begin{numcases}{}
             y'=y(y-1)\sin(yt)\\
-            y(0)=\frac{ 1 }{2}.
+            y(0)=\frac{1}{2}.
         \end{numcases}
     \end{subequations}
-    La fonction \( f(t,y)=y(y-1)\sin(yt)\) ayant une dérivée bornée partout, est localement Lipschitz et le théorème de Cauchy-Lipschitz~\ref{ThokUUlgU} s'applique. Pour toute condition initiale, une solution maximale unique existe.
+    La fonction \( f(t,y)=y(y-1)\sin(yt)\) ayant une dérivée bornée partout, elle est localement Lipschitz et le théorème de Cauchy-Lipschitz~\ref{ThokUUlgU} s'applique. Pour toute condition initiale, une solution maximale unique existe.
 
     Si nous oublions la condition initiale, il est facile de trouver des solutions constantes : \( y'=0\) avec \( y(t)=k\) donne l'équation
     \begin{equation}
@@ -136,12 +136,12 @@ Soit un compact \( K\).Supposons que que pour tout \( t_0<t_{max}\) il existe \(
     \begin{subequations}
         \begin{numcases}{}
             y_i'(t)=f\big( t,y_i(t) \big)\\
-            y_i(t_0)=a_i
+            y_i(t_0)=a_i.
         \end{numcases}
     \end{subequations}
     Alors pour tout \( t\in I_1\cap I_2\) nous pouvons estimer l'écart entre \( y_1\) et \( y_2\) par la formule
     \begin{equation}
-        \| y_1(t)-y_2(t) \|\leq  e^{L| t-t_0 |}\| a_1-a_2 \|
+        \| y_1(t)-y_2(t) \|\leq  e^{L| t-t_0 |}\| a_1-a_2 \|,
     \end{equation}
     où \( L\) est la constante de Lipschitz de \( f\).
 \end{proposition}
@@ -152,7 +152,7 @@ Soit un compact \( K\).Supposons que que pour tout \( t_0<t_{max}\) il existe \(
         \begin{align}
             \| y_1(t)-y_2(t) \|&=\| \int_{t_0}^t\big( y'_1(s)-y'_1(s) \big) \|\\
             &\leq L\int_{t_0}^t\| f\big( s,y_1(s) \big)-f\big( s,y_2(s) \big) \|ds\\
-            &=L\int_{t_0}^t\| y_1(s)-y_2(s) \|ds
+            &=L\int_{t_0}^t\| y_1(s)-y_2(s) \|ds.
         \end{align}
     \end{subequations}
     C'est à ce moment que nous utilisons le lemme de Grönwall. Vu que
@@ -210,7 +210,7 @@ Il se fait que l'application \( (t,a)\mapsto y_a(t)\) a la même régularité qu
     \begin{equation}
         \begin{aligned}
             \varphi_t\colon \eR^n&\to \eR^n \\
-            x&\mapsto \varphi(t,x) = y_x(t)
+            x&\mapsto \varphi(t,x) = y_x(t),
         \end{aligned}
     \end{equation}
     est le \defe{flot}{flot} du problème de Cauchy \eqref{EQooADJMooRAZWfm}.
@@ -218,7 +218,7 @@ Il se fait que l'application \( (t,a)\mapsto y_a(t)\) a la même régularité qu
     L'application \( t\mapsto \varphi_t\) est ce qui est appelé le groupe à un paramètre de flot, pour des raisons qui arriverons plus tard\quext{ou pas\ldots}.
 \end{definition}
 
-Le but est d'étudier les propriétés du flot : est-il continu, une difféomorphisme, existe, pour quels \( t\) ? Où se cache le champ de vecteurs du titre dans l'équation différentielle ?
+Le but est d'étudier les propriétés du flot : est-il continu, un difféomorphisme, existe, pour quels \( t\) ? Où se cache le champ de vecteurs du titre dans l'équation différentielle ?
 
 Nous posons
 \begin{equation}
@@ -238,7 +238,7 @@ Comme tout produit d'espaces métrique, l'ensemble \( \mD\) est muni d'une métr
 
     Nous posons
     \begin{equation}
-        \mD=\bigcup_{x\in\Omega}\big( J_x\times \{ x \} \big)
+        \mD=\bigcup_{x\in\Omega}\big( J_x\times \{ x \} \big).
     \end{equation}
     Nous définissons la fonction \( \varphi\) par \( \varphi(t,x)=y_x(t)\) là où ça existe.
 
@@ -324,7 +324,6 @@ Nous allons prouver que \( X=J_{+}\) en prouvant qu'il est ouvert, fermé et non
 
             C'est parce que \( \overline{ W_{\epsilon} }\) et \( J_b\) sont fermés.
 
-
         \item[\( X\) est ouvert]
 
             Soit \( \tau\in X\). Si \( \tau=\sup J_+\) alors \( X=J_+\) est un ouvert de \( J_+\). Supposons donc que \( 0<\tau<\sup J_+\). Dans ce cas nous avons
@@ -395,8 +394,8 @@ Nous allons prouver que \( X=J_{+}\) en prouvant qu'il est ouvert, fermé et non
 
     Il nous reste à voir que \( \varphi\colon \mD\to \Omega\) est localement Lipschitz. Soit donc le point générique \( (s,a)\) dans \( \mD\) et l'ensemble $V$ qui avait été construit plus haut. Nous allons montrer que \( \varphi\) est Lipschitz sur \( J\times \overline{ B(a,r) }\subset V\). D'abord sur \( V\), l'application \( f\) est Lipschitz, donc
     \begin{equation}
-            \| \varphi(t,b_1)-\varphi(t,b_2) \|\leq  e^{Lt}\| b_1-b_2 \|
-            \leq  e^{LT}\| b_1-b_2 \|
+         \| \varphi(t,b_1)-\varphi(t,b_2) \|\leq  e^{Lt}\| b_1-b_2 \|
+         \leq  e^{LT}\| b_1-b_2 \|
     \end{equation}
     pour tout \( t\in J\) et \( b_1,b_2\in \overline{ B(a,r) }\).
 
@@ -449,7 +448,7 @@ Nous allons prouver que \( X=J_{+}\) en prouvant qu'il est ouvert, fermé et non
     \end{equation}
     Et cette solution tient en réalité pour tout \( s\) parce que \( X(s)\) est alors toujours positif.
 
-    Si au contraire \( x<0  \) nous avons la solution
+    Si au contraire \( x<0 \) nous avons la solution
     \begin{equation}
         X(s)=x e^{t-s}.
     \end{equation}
@@ -863,7 +862,7 @@ Nous allons prouver que \( X=J_{+}\) en prouvant qu'il est ouvert, fermé et non
     En fait, à la place de \( I\) et \( \Omega\) il faut prendre des petits voisinages dans lesquels les choses ont un sens. Ce que dit l'équation~\ref{EQooBETGooXKWRxX} est que l'application
     \begin{equation}
         \begin{aligned}
-            A\colon I\times \Omega&\to \aL(\eR^n) \\
+            A\colon I \times \Omega&\to \aL(\eR^n) \\
             (t,x)&\mapsto (d\varphi_t)_x
         \end{aligned}
     \end{equation}


### PR DESCRIPTION
- Plus des points et espaces manquants rajoutés dans les équations.