### PR TITLE
Correction mineure dans la démonstration de 1.50

### DIFF
--- a/mazhe.bib
+++ b/mazhe.bib
@@ -3950,7 +3950,7 @@ title = {Éléments de géométrie différentielle},
 
 @ARTICLE{RWWJooJdjxEK,
     author = {Laurent-Thiébaut, Christine},
-    title = {Aximatique des nombres},
+    title = {Axiomatique des nombres},
     year = {},
     url = "http://ljk.imag.fr/membres/Bernard.Ycart/mel/ax/ax.pdf",
 }

--- a/tex/frido/42_nombres.tex
+++ b/tex/frido/42_nombres.tex
@@ -571,7 +571,7 @@ La proposition suivante donne une bijection explicite entre \( \eN\) et \( \eN\t
                 \item
                     l'équation \( f(x,y)=k\) possède au maximum une solution avec \( y\leq x\),
                 \item
-                    si \(   k=y^2+x \) avec \( x<y\) alors il est impossible que \( k=x'^2+y'\) avec \( y\leq x\).
+                    si \(   k=y^2+x \) avec \( x<y\) alors il est impossible que \( k=x'^2+x'+y'\) avec \( y'\leq x'\).
             \end{enumerate}
             Supposons \( k=y^2+x\) avec \( x<y\). Alors aucun \( y'\) de la forme \( y+s\) ne peut être solution parce que
             \begin{equation}


### PR DESCRIPTION
Sauf erreur de ma part, on veut démontrer que la formule du haut (y²+x) si x<y ne peut jamais être égale à celle du bas (x²+x+y) si y<=x.

Corrige aussi une typo dans la bibliographie.