### PR TITLE
Typos

### DIFF
--- a/tex/frido/42_nombres.tex
+++ b/tex/frido/42_nombres.tex
@@ -1003,7 +1003,7 @@ La proposition suivante montre encore que le corps des fractions est le plus pet
         \item       \label{ITEMooKZZYooDaidGU}
             Un corps totalement ordonné est \defe{complet}{corps!complet}\index{complet!corps} si toute suite de Cauchy y est convergente.
         \item       \label{ITEMooMWASooEzhVyh}
-            Si \( x,\epsilon\in \eK\) alors nous définissons la \defe{boule ouverte}{boule dans un corps} de centre \( a\) et de rayon \( \epsilon\) par
+            Si \( x,\epsilon\in \eK\) alors nous définissons la \defe{boule ouverte}{boule dans un corps} de centre \( x\) et de rayon \( \epsilon\) par
             \begin{equation}
                 B(x,\epsilon)=\{ y\in \eK\tq | x-y |<\epsilon \},
             \end{equation}

--- a/tex/frido/42_nombres.tex
+++ b/tex/frido/42_nombres.tex
@@ -1085,7 +1085,7 @@ Parmi ces définitions, celles de suite convergente, de Cauchy et de corps compl
         \item       \label{ITEMooXJGVooSebiip}
             Nous avons \( y\in B(x,\epsilon)\) si et seulement si \( x-\epsilon<y<x+\epsilon\).
         \item       \label{ITEMooRUBBooRayiMs}
-            Si \( y\in  \overline{ B(x,\epsilon) }  \) alors \( y\in B(x,\epsilon')\) pour tout \( \epsilon'<\epsilon\).
+            Si \( y\in  \overline{ B(x,\epsilon) }  \) alors \( y\in B(x,\epsilon')\) pour tout \( \epsilon'>\epsilon\).
     \end{enumerate}
 \end{lemma}
 


### PR DESCRIPTION
 - la définition de boule ouverte mentionne un centre a qui n'apparaît nul part ailleurs, ce devrait être x
 - une boule fermée est inclue dans toute boule ouverte de rayon supérieur (et non pas inférieur)