### PR TITLE
Justification du fait que le groupe dérivé est non-vide

### DIFF
--- a/tex/frido/46_groupes.tex
+++ b/tex/frido/46_groupes.tex
@@ -259,7 +259,7 @@ Le théorème de Burnside~\ref{ThooJLTit} nous donnera un bon paquet d'exemples 
 \begin{definition}\label{DefVUFBooNQjEdn}
     Si \( G\) est un groupe et si \( g,h\in G\), nous notons \( [g,h]=ghg^{-1}h^{-1}\)\nomenclature[R]{\( [g,h]\)}{commutateur dans un groupe} le \defe{commutateur}{commutateur!dans un groupe} de \( g\) et \( h\). Le \defe{groupe dérivé}{dérivé!groupe}\index{groupe!dérivé} de \( G\) est le sous-groupe noté \( D(G)\)\nomenclature[R]{\( D(G)\)}{groupe dérivé} ou \( [G,G]\)\nomenclature[R]{\( [G,G]\)}{groupe dérivé} engendré par les commutateurs.
 \end{definition}
-Autrement dit, \( D(G)\) est l'intersection de tous les sous-groupes de \( G\) contenant tous les commutateurs. Intersection non vide parce que l'élément neutre au moins en fait partie: pour \( g=h \), \( [g,g]=ggg{-1}g^{-1}=e \).
+Autrement dit, \( D(G)\) est l'intersection de tous les sous-groupes de \( G\) contenant tous les commutateurs. Intersection non vide parce que l'élément neutre au moins en fait partie: pour \( g=h \), \( [g,g]=ggg^{-1}g^{-1}=e \).
 
 En vertu du lemme~\ref{LemFUIZooBZTCiy}, le groupe dérivé de \( G\) est l'ensemble des produits finis de commutateurs. C'est-à-dire que si \( S_m\) est l'ensemble des produits de \( m\) commutateurs, alors
 \begin{equation}

--- a/tex/frido/46_groupes.tex
+++ b/tex/frido/46_groupes.tex
@@ -259,7 +259,7 @@ Le théorème de Burnside~\ref{ThooJLTit} nous donnera un bon paquet d'exemples 
 \begin{definition}\label{DefVUFBooNQjEdn}
     Si \( G\) est un groupe et si \( g,h\in G\), nous notons \( [g,h]=ghg^{-1}h^{-1}\)\nomenclature[R]{\( [g,h]\)}{commutateur dans un groupe} le \defe{commutateur}{commutateur!dans un groupe} de \( g\) et \( h\). Le \defe{groupe dérivé}{dérivé!groupe}\index{groupe!dérivé} de \( G\) est le sous-groupe noté \( D(G)\)\nomenclature[R]{\( D(G)\)}{groupe dérivé} ou \( [G,G]\)\nomenclature[R]{\( [G,G]\)}{groupe dérivé} engendré par les commutateurs.
 \end{definition}
-Autrement dit, \( D(G)\) est l'intersection de tous les sous-groupes de \( G\) contenant tous les commutateurs. Intersection non vide parce que \( G\) lui-même en fait partie.
+Autrement dit, \( D(G)\) est l'intersection de tous les sous-groupes de \( G\) contenant tous les commutateurs. Intersection non vide parce que l'élément neutre au moins en fait partie: pour \( g=h \), \( [g,g]=ggg{-1}g^{-1}=e \).
 
 En vertu du lemme~\ref{LemFUIZooBZTCiy}, le groupe dérivé de \( G\) est l'ensemble des produits finis de commutateurs. C'est-à-dire que si \( S_m\) est l'ensemble des produits de \( m\) commutateurs, alors
 \begin{equation}


### PR DESCRIPTION
Le fait que G fasse partie des ensembles de l'intersection ne signifie pas que l'intersection est non vide. Par contre l'élément neutre est nécessairement présent.