### PR TITLE
Environnement proof: paramètre inBook

### DIFF
--- a/e_mazhe.tex
+++ b/e_mazhe.tex
@@ -958,6 +958,19 @@
 %\renewcommand{\labelenumii}{(\theenumii)}
 
 
+% Possibilité d’omettre une preuve en définissant l’argument optionnel inBook=False
+\usepackage{keycommand}
+\usepackage{verbatim}  % Fournit l’environnement comment
+
+\NewCommandCopy\oldproof\proof
+\NewCommandCopy\endoldproof\endproof
+
+\renewkeyenvironment{proof}[inBook=True]{%
+  \ifthenelse{\equal{\commandkey{inBook}}{False}}{\emph{Voir la version en ligne}\comment}{\oldproof}
+}{
+  \ifthenelse{\equal{\commandkey{inBook}}{False}}{\endcomment}{\endoldproof}
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %


### PR DESCRIPTION
Le paramètre inBook permet, si défini sur False, de ne pas afficher des démonstrations afin de gagner de la place.
Fait suite à l’[article sur LinuxFr](https://linuxfr.org/news/y-a-le-frido-2024-qu-est-la#toc-latex).