### PR TITLE
Typos, petite réorganiation

### DIFF
--- a/tex/frido/188_EspacesVectos.tex
+++ b/tex/frido/188_EspacesVectos.tex
@@ -323,7 +323,7 @@ Notez que dans cette proposition, nous ne supposons pas que \( a\) soit dans \( 
 	\end{enumerate}
 \end{proposition}
 
-En utilisant les notations du complémentaire (\ref{AppComplement}), les deux points de la proposition se récrivent
+En utilisant les notations du complémentaire (définition~\ref{DEFooJLBVooMyCQMO}), les deux points de la proposition se récrivent
 \begin{enumerate}
 	\item
 	      \( \complement \bar A=\Int(\complement A)\),

--- a/tex/frido/42_nombres.tex
+++ b/tex/frido/42_nombres.tex
@@ -58,9 +58,6 @@
 
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 \section{Quelques éléments sur les ensembles}
-%+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-\section{Quelques éléments sur les ensembles}
 \label{SECooEltsEnsembles}
 %+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -68,7 +65,7 @@ Tout cela pour dire que le Frido ne traitera que de la partie facile de la math�
 
 %---------------------------------------------------------------------------------------------------------------------------
 \subsection{Opérations ensemblistes}
-\label{SUBooOperationsEnsemblistes}\label{AppComplement}%dans 188_EspacesVectos.tex (097)
+\label{SUBooOperationsEnsemblistes}
 %---------------------------------------------------------------------------------------------------------------------------
 
 \begin{normaltext}\label{NorooFridoIntro2}
@@ -79,15 +76,11 @@ Tout cela pour dire que le Frido ne traitera que de la partie facile de la math�
 		\item
 		      ensemble, appartenance, intersection, union,
 		\item
-		      produit cartésien de plusieurs ensembles.
+		      produit cartésien de plusieurs ensembles\footnote{Nous en proposons une définition dans un cadre général -- définition \ref{DEFooTYIMooZUsYJw} --, dont les fondements devraient être analysés de très près.}.
+% TODO réf futur OK.
 	\end{enumerate}
 	Ce sont toutes des choses dont la construction à partir des axiomes n'est en aucun cas évidente. En particulier, des «définitions» comme «l'intersection de deux ensembles est l'ensemble contenant exactement les éléments communs aux deux ensembles» ne sont pas correctes parce qu'elles passent à côté de l'existence et de l'unicité d'un tel ensemble.
 \end{normaltext}
-
-
-\begin{definition}[Produit cartésien\cite{BIBooRNUTooNwYWtS}]	\label{DEFooTYIMooZUsYJw}
-	Soit un ensemble \( I\) ainsi qu'une collection d'ensembles \( \{ A_i \}_{i\in I}\). Nous notons \( \prod_{i\in I}A_i\) l'ensemble des applications \(f \colon I\to \bigcup A_i  \) telles que \( f(i)\in A_i\).
-\end{definition}
 
 \begin{definition}		\label{DEFooJLBVooMyCQMO}
 	Soit \( E\), un ensemble et \( A\), une partie de \( E\) (c'est-à-dire un sous-ensemble de \( E\)). Le \defe{complémentaire}{complémentaire} de l'ensemble \(A \), dans \( E\), noté \( \complement A\)\nomenclature[T]{\( \complement A\)}{Le complémentaire de l'ensemble \( A\)} est l'ensemble des éléments de \( E\) qui ne font pas partie de \( A\) :
@@ -115,6 +108,8 @@ Tout cela pour dire que le Frido ne traitera que de la partie facile de la math�
 
 	La suite de ce chapitre sera essentiellement sans exemple parce qu'avant d'avoir construit les ensembles de nombres, je ne sais pas très bien quels exemples on peut donner de quoi que ce soit.
 \end{normaltext}
+
+
 
 
 %---------------------------------------------------------------------------------------------------------------------------
@@ -242,6 +237,10 @@ Les plus \randomGender{acharnés}{acharnées} parmi les \randomGender{lecteurs}{
 		Si \( f \) est injective, et si \( X\cap Y = \varnothing \), alors il n'y a aucun élément dans \( f(X\cap Y)=f(X)\cap f(Y) \).
 	\end{subproof}
 \end{proof}
+
+\begin{definition}[Produit cartésien infini\cite{BIBooRNUTooNwYWtS}]	\label{DEFooTYIMooZUsYJw}
+	Soit un ensemble \( I\) ainsi qu'une collection d'ensembles \( \{ A_i \}_{i\in I}\). Nous notons \( \prod_{i\in I}A_i\) l'ensemble des applications \(f \colon I\to \bigcup A_i  \) telles que \( f(i)\in A_i\).
+\end{definition}
 
 %---------------------------------------------------------------------------------------------------------------------------
 \subsection{Ensemble ordonné}
@@ -1407,7 +1406,7 @@ Nous donnons deux preuves de ce lemme.
 \label{SUBooComparabiliteCardinale}
 %---------------------------------------------------------------------------------------------------------------------------
 
-Le théorème de comparabilité cardinale énonce que si \( A\) et \( B\) sont des ensemble, alors nous avons toujours \( A\succeq B\) ou \( A\preceq B\) (ou les deux; dans ce cas \( A\approx B\) par Cantor-Schröder-Bernstein).
+Le théorème de comparabilité cardinale énonce que si \( A\) et \( B\) sont des ensembles, alors nous avons toujours \( A\succeq B\) ou \( A\preceq B\) (ou les deux; dans ce cas \( A\approx B\) par Cantor-Schröder-Bernstein).
 \begin{theorem}[Théorème de comparabilité cardinale\cite{MonCerveau,BIBooTSOKooCWxMwj,BIBooZZNRooZytRuC}]     \label{THOooCBSKooCmzfUf}
 	Entre deux ensembles, il existe forcément une injection de l'un dans l'autre.
 \end{theorem}
@@ -1626,9 +1625,12 @@ Notons que nous avons écrit \( g\cdot h\) et non \( \cdot(g,h)\) comme une nota
 
 	Dans un anneau commutatif, nous disons que \( a\) \defe{divise}{divise} \( b\) si il existe \( x\in A\) tel que \( ax=b\). Dans ce cas nous écrivons \( a\divides b\).
 \end{definition}
-Un cas particulier est le cas des diviseurs de zéro. L'absence de tels diviseurs dans un anneau est une propriété intéressante: on dit dans ce cas que l'anneau est intègre. Définition \ref{DEFooTAOPooWDPYmd}.
+Un cas particulier est le cas des diviseurs de zéro. L'absence de tels diviseurs dans un anneau est une propriété intéressante: on dit dans ce cas que l'anneau est \emph{intègre}. Nous définissons cela proprement en la définition \ref{DEFooTAOPooWDPYmd}, grâce à des propriétés équivalentes.
 
-Un élément \( a\in A\) est \defe{régulier à droite}{régulier à droite} si \( ba=0\) implique \( b=0\). Il est régulier à gauche si \( ab=0\) implique \( b=0\).
+
+\begin{definition}\label{DEFooAnneauEltRegulier}
+	Un élément \( a\in A\) est \defe{régulier à droite}{anneau!élément régulier} si, dès lors qu'un élément \( b \in a \) est tel que \( ba=0\), alors \( b=0\). Il est régulier à gauche si \( ab=0\) implique \( b=0\).
+\end{definition}
 
 \begin{definition}          \label{DefrYwbct}
 	Soient \( A\) un anneau commutatif et \( S\subset A\). Nous disons que \( \delta\in A\) est un \defe{PGCD}{pgcd!dans un anneau intègre} de \( S\) si


### PR DESCRIPTION
Bonjour Laurent,

Les modifs en résumé:
- un titre de section a été dupliqué par erreur (mea culpa), il est retiré;*
- produit cartésien que tu as défini: je le mets plus loin parce qu'il nécessite les fonctions;
- gestion de quelques refs.
Merci !