### PR TITLE
Update 239_nombres.tex

### DIFF
--- a/tex/frido/239_nombres.tex
+++ b/tex/frido/239_nombres.tex
@@ -873,7 +873,7 @@ La notion de parité d'une permutation est la clef pour savoir quelles positions
 \end{proof}
 
 %-------------------------------------------------------
-\subsection{Permutation un peu ordonnées}
+\subsection{Permutations un peu ordonnées}
 %----------------------------------------------------
 
 \begin{lemma}[\cite{MonCerveau}]		\label{LEMooEOTGooPslULz}


### PR DESCRIPTION
« ordonnées » étant au pluriel, je propose que « Permutation » le soit également pour l'accord grammatical. Ou alors si « Permutation » est conservé au singulier, « ordonnée » doit l'être également. J'ignore quelle était votre intention dans ce titre, mais je pense que le plus probable était bien de parler des permutations, pas d'une seule.