### PR TITLE
Update corrTD6A-0002.tex (mot manquant)

### DIFF
--- a/tex/exocorr/corrTD6A-0002.tex
+++ b/tex/exocorr/corrTD6A-0002.tex
@@ -49,7 +49,7 @@ sage: f(x)=1/sqrt(1-x**2)
 sage: f.integrate(x)
 x |--> arcsin(x)
             \end{verbatim}
-            Notez que \href{http://sagemath.org}{Sage} ne vous donne constante d'intégration\footnote{Vous pouvez voir votre cours de math comme un cours d'anticipation des fautes que vous commettriez si vous vous fiiez trop facilement à votre calculatrice ou votre ordinateur.} ni domaines\footnote{Il ne peut pas savoir quel est le contexte dans lequel vous êtes en train de calculer !} (nous y reviendrons). Nous avons :
+            Notez que \href{http://sagemath.org}{Sage} ne vous donne ni constante d'intégration\footnote{Vous pouvez voir votre cours de math comme un cours d'anticipation des fautes que vous commettriez si vous vous fiiez trop facilement à votre calculatrice ou votre ordinateur.} ni domaines\footnote{Il ne peut pas savoir quel est le contexte dans lequel vous êtes en train de calculer !} (nous y reviendrons). Nous avons :
             \begin{equation}
                 t=\arcsin(x)+C.
             \end{equation}


### PR DESCRIPTION
Je suppose que le mot "ni" est manquant devant "constante" (ne vous donne ni constante d'intégration, ni domaines)