### PR TITLE
Update corr_I-3-5.tex (cos en caractères droits)

### DIFF
--- a/tex/exocorr/corr_I-3-5.tex
+++ b/tex/exocorr/corr_I-3-5.tex
@@ -48,7 +48,7 @@ Pour prouver l'existence, nous procédons comme pour $F$ :
 \end{equation}
 Nous en déduisons que l'intégrale \eqref{EqIntPartialAvUtCorr35} existe pour tout $x\neq 0$.
 
-Maintenant, nous voudrions bien borner $\frac{ cos(xt) }{ \sin(xt)^{4/3} }$ de façon indépendante de $x$ pour $x\in K\subset ]0,1[$. Nous serions donc content que cette fonction soit soit croissante soit décroissante sur $]0,1[$. En réalité, elle est décroissante parce que si nous posons
+Maintenant, nous voudrions bien borner $\frac{ \cos(xt) }{ \sin(xt)^{4/3} }$ de façon indépendante de $x$ pour $x\in K\subset ]0,1[$. Nous serions donc content que cette fonction soit soit croissante soit décroissante sur $]0,1[$. En réalité, elle est décroissante parce que si nous posons
 \begin{equation}
 		l(y)=\frac{ \cos(y) }{ \sin(y)^{4/3} },
 \end{equation}


### PR DESCRIPTION
Ajout de la contre-oblique pour composer cos en caractères droits.