### PR TITLE
Update corrTP20090003.tex (lettres manquantes)

### DIFF
--- a/tex/exocorr/corrTP20090003.tex
+++ b/tex/exocorr/corrTP20090003.tex
@@ -308,9 +308,9 @@ déterminer le plan tangent au tore en un point $p_0 = (x_0,y_0,z_0)$~:
 il est donné par l'équation
 \begin{equation}
 	\begin{aligned}[]
-  &4 (x_02 + y_02 + z_02 - R2 - r2) x_0 (x - x_0)\\ 
-  &+ 4 (x_02 +y_02 + z_02 - R2 - r2) y_0 (y - y_0)\\
-  &+ 4 (x_02 + y_02 + z_02 + R2 - r2) z_0 (z - z_0) = 0.
+  &4 (x_0^2 + y_0^2 + z_0^2 - R^2 - r^2) x_0 (x - x_0)\\ 
+  &+ 4 (x_0^2 +y_0^2 + z_0^2 - R^2 - r^2) y_0 (y - y_0)\\
+  &+ 4 (x_0^2 + y_0^2 + z_0^2 + R^2 - r^2) z_0 (z - z_0) = 0.
 	\end{aligned}
 \end{equation}
 Ceci n'est valable que si la forme implicite est ``la bonne'' (il faut


### PR DESCRIPTION
"consiste à coup" -> "consiste à couper" +  ajout de mise en exposant manquants