### PR TITLE
Update KG.tex (Correction nom Unterberger + contre-oblique manquante)

### DIFF
--- a/tex/research/KG.tex
+++ b/tex/research/KG.tex
@@ -514,7 +514,7 @@ and we know that $dp$ is an invariant measure on $\eR^4$ under the group $\LoL_0
 \[
 	\int_{\eR^4}\hat f(\overline{p},y)\frac{ dy }{ 2p_0 }\,d\overline{p}
 \]
-where $\frac{ dy }{ 2p_0 }d\overline{p}$ is an invariant measure. The mass hyperboloid is given by equation $y=m^2$ (we usually set $m=1$). The variable $y$ is invariant under $LoL_0$, so we define ``$p_0^{-1}d\overline{p}$'' by the expression
+where $\frac{ dy }{ 2p_0 }d\overline{p}$ is an invariant measure. The mass hyperboloid is given by equation $y=m^2$ (we usually set $m=1$). The variable $y$ is invariant under $\LoL_0$, so we define ``$p_0^{-1}d\overline{p}$'' by the expression
 \begin{equation}
 	\int_{\scrM}f(p)p_0^{-1}d\overline{p}= \int_{\eR^4}\hat f(\overline{p},y)\delta(y-m^2)\frac{ dy\,d\overline{p} }{ \sqrt{m^2+\overline{p}^2} }
 \end{equation}
@@ -868,7 +868,7 @@ Let us now prove that \eqref{eq_xtozzeq} is surjective: for all $z\in\eR^{n+1}$ 
 If $d\overline{x}$ is the measure on $E_0$, which is the corresponding measure $d\overline{ z }$ on $E_p$?
 
 \begin{probleme}
-	Toujours le même truc d'Unterbeger que je ne comprends pas sur sa façon de trouver les $d\overline{ z }$ en fonction des $d\overline{ x }$.
+	Toujours le même truc d'Unterberger que je ne comprends pas sur sa façon de trouver les $d\overline{ z }$ en fonction des $d\overline{ x }$.
 \end{probleme}
 The answer is
 \begin{equation}


### PR DESCRIPTION
Je ne suis pas complètement certain que ma correction LoL_0 -> \LoL_0 soit correcte, mais en l'état le produit de L par o par L_0 ne semble pas avoir de sens, alors que \LoL_0 est déjà employé précédemment donc j'ai bon espoir de ne pas faire de bourde avec ce pull request.