### PR TITLE
Update 42_nombres.tex (ajouts de \hline)

### DIFF
--- a/tex/frido/42_nombres.tex
+++ b/tex/frido/42_nombres.tex
@@ -855,13 +855,17 @@
 		Nous écrivons les tables de vérités selon que \( x\) est dans \( A\), \( B\), \( C\) ou non. D'abord
 		\begin{equation}
 			\begin{array}{|c|c|c|c|c|c|c|c|c|}
+				\hline%
 				A                   & 1 & 1 & 1 & 1 & 0 & 0 & 0 & 0 \\
+				\hline%
 				B                   & 1 & 1 & 0 & 0 & 1 & 1 & 0 & 0 \\
+				\hline%
 				C                   & 1 & 0 & 1 & 0 & 1 & 0 & 1 & 0 \\
 				\hline%
 				B\Delta C           & 0 & 1 & 1 & 0 & 0 & 1 & 1 & 0 \\
 				\hline%
-				A\Delta (B\Delta C) & 1 & 0 & 0 & 1 & 0 & 1 & 1 & 0
+				A\Delta (B\Delta C) & 1 & 0 & 0 & 1 & 0 & 1 & 1 & 0\\
+				\hline%
 			\end{array}
 		\end{equation}
 		La quatrième ligne s'écrit sur le modèle de \eqref{EQooOJBOooKkKbYp} en regardant les deuxièmes et troisièmes lignes. La dernière ligne se fait avec la première et la quatrième.
@@ -869,13 +873,17 @@
 		L'autre table de vérité se fait de la même manière :
 		\begin{equation}
 			\begin{array}{|c|c|c|c|c|c|c|c|c|}
+				\hline%
 				A                   & 1 & 1 & 1 & 1 & 0 & 0 & 0 & 0 \\
+				\hline%
 				B                   & 1 & 1 & 0 & 0 & 1 & 1 & 0 & 0 \\
+				\hline%
 				C                   & 1 & 0 & 1 & 0 & 1 & 0 & 1 & 0 \\
 				\hline%
 				A\Delta B           & 0 & 0 & 1 & 1 & 1 & 1 & 0 & 0 \\
 				\hline%
-				(A\Delta B)\Delta C & 1 & 0 & 0 & 1 & 0 & 1 & 1 & 0
+				(A\Delta B)\Delta C & 1 & 0 & 0 & 1 & 0 & 1 & 1 & 0\\
+				\hline%
 			\end{array}
 		\end{equation}
 		Puisque les lignes pour \( A\Delta (B\Delta C)\) et pour \( (A\Delta B)\Delta C\) sont identiques, nous avons égalité.


### PR DESCRIPTION
Il me semble qu'il manque des \hline pour les tableaux des équations numérotées actuellement 1.28 et 1.28 (situé entre ITEMooSMXWooYcWsRC et appEquivalence). Peut-être ne vouliez-vous pas une séparation entre la première et la seconde ligne (la ligne des A et celle des B) et entre la seconde et la troisième (la ligne des B et celle des C), mais dans le doute je les ai placées quand même.