### PR TITLE
Update 164_thm.tex (à vérifier :  | G | / | G |)

### DIFF
--- a/tex/front_back_matter/164_thm.tex
+++ b/tex/front_back_matter/164_thm.tex
@@ -21,7 +21,7 @@
 	\item
 	      L'ordre d'un élément divise l'ordre du groupe, corolaire \ref{CorpZItFX}.
 	\item
-	      Si \( H\) est normal dans \( G\), alors \( | G/H |=| G |/| G |\), théorème de Lagrange \ref{ThoLagrange}.
+	      Si \( H\) est normal dans \( G\), alors \( | G/H |=| G |/| H |\), théorème de Lagrange \ref{ThoLagrange}.
 	\item
 	      Si \( G\) est un groupe cyclique, pour tout diviseur \( p\) de \( | G |\), le groupe \( G\) contient au moins un élément d'ordre \( p\). Théorème de Cauchy \ref{THOooSUWKooICbzqM}.
 \end{enumerate}


### PR DESCRIPTION
Ça me semble bizarre que ça soit | G | / | G |, l'écriture  | G | / | H | me semble plus « crédible ». Je ne connais pas assez le domaine pour avoir une quelconque certitude (par exemple le symbole ici est-il celui de la division ordinaire ? Auquel cas effectivement | G | / | G | se simplifierait et vaudrait 1...). Je préfère prendre le risque de signaler un faux positif que de laisser passer une erreur potentielle. Mes excuses si c'est un faux positif.