### PR TITLE
Update corrExosenvrac-0006.tex (ajout d'une ligne vide, indispensable…

### DIFF
--- a/tex/exocorr/corrExosenvrac-0006.tex
+++ b/tex/exocorr/corrExosenvrac-0006.tex
@@ -1,6 +1,6 @@
 \begin{corrige}{Exosenvrac-0006}
  
-L'équation $x'=tx^2$ peut se résoudre par séparation de variables parce que le membre de droite de l'équation est le produit d'une fonction de $t$, à l'occurrence l'identité, et une fonction qui ne dépend explicitement que de $x$ : $x^2$. 
+L'équation $x'=tx^2$ peut se résoudre par séparation de variables parce que le membre de droite de l'équation est le produit d'une fonction de $t$, en l'occurrence l'identité, et une fonction qui ne dépend explicitement que de $x$ : $x^2$. 
 
 La seule solution constante de l'équation est $x(t)=0$. 
 
@@ -26,4 +26,5 @@ La solution du problème de Cauchy
   \end{cases}
 \end{equation} 
 n'est pas la solution constante. Il faut alors supposer qu'elle soit de la forme $\displaystyle x(t)= -\frac{1}{\frac{ t^2 }{2}+C}$ et calculer $\displaystyle x(2)= -\frac{1}{2+C}$. La condition $\displaystyle  -\frac{1}{2+C}=1$ nous permet de trouver la valeur de la constante $C$ qui détermine l'unique solution du problème de Cauchy. Ici : $C = -3$.
+
 \end{corrige}


### PR DESCRIPTION
… pour séparer la correction de l'énoncé de l'exercice suivant)

Cette ligne vide permet d'éviter de se retrouver avec un texte comme : « Ici : C = -3. Exercice 198 (4 points) » sur une seule ligne. Le problème que cela résout est visible au niveau de l'étiquette « exoExosenvrac-0009 » sur le PDF.

<img width="786" height="166" alt="image" src="https://github.com/user-attachments/assets/bc070e91-9515-47a2-a3ec-f69f964c3e69" />

J'ai également remplacé « à l'occurrence » par « en l'occurrence », qui est l'expression correcte ici (= dans le cas qui nous concerne ici).