### PR TITLE
Update code_sage2.py (erreur de syntaxe depuis que Sage emploie Python3)

### DIFF
--- a/tex/frido/code_sage2.py
+++ b/tex/frido/code_sage2.py
@@ -1,11 +1,11 @@
 from scipy import stats
 
 N=stats.norm
-print N.mean()      # 0
-print N.var()       # 1
+print(N.mean())      # 0
+print(N.var())       # 1
 
 xi = N.isf(0.95)
-print xi            # -1.64485
+print(xi)            # -1.64485
 
 N.cdf(xi)           # Vérification : 0.05
 


### PR DESCRIPTION
Les print nécessitent des parenthèses. L'erreur est : SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?